### PR TITLE
Add browser-based Meditation Builder

### DIFF
--- a/meditation/builder.css
+++ b/meditation/builder.css
@@ -1,0 +1,43 @@
+.builder-hero { background: linear-gradient(135deg, #17151b 20%, #56305d); padding: 5rem 0 4rem; text-align: center; }
+.builder-hero h1 { font-size: clamp(2.3rem, 6vw, 4rem); font-weight: 700; }
+.builder-hero > .container > p:last-child { color: var(--muted); font-size: 1.1rem; margin: 1rem auto 0; max-width: 42rem; }
+.builder-layout { display: grid; gap: 2rem; grid-template-columns: minmax(0, 1.5fr) minmax(280px, .8fr); padding-bottom: 4rem; padding-top: 4rem; }
+.builder-panel, .preview-panel { background: var(--card); border: 1px solid #403a48; border-radius: .85rem; padding: clamp(1.25rem, 3vw, 2rem); }
+.preview-panel { align-self: start; position: sticky; top: 5rem; }
+.builder-row { display: grid; gap: 1rem; grid-template-columns: 1fr 1fr; }
+.builder-panel label, .builder-panel legend { color: var(--ink); font-weight: 700; }
+.builder-panel legend { font-size: 1rem; }
+.field-help, .builder-panel small, .preview-panel p, .player-note { color: var(--muted); }
+.segment-options { display: grid; gap: .75rem; grid-template-columns: 1fr 1fr; margin-bottom: 1.5rem; }
+.segment-options label { align-items: flex-start; background: #1b1920; border: 1px solid #494250; border-radius: .65rem; cursor: pointer; display: flex; gap: .75rem; margin: 0; padding: 1rem; }
+.segment-options label:focus-within { outline: 3px solid #dfb8e6; outline-offset: 2px; }
+.segment-options input { margin-top: .3rem; }
+.segment-options span { display: grid; }
+.segment-options small { font-weight: 400; }
+.settings-row { margin-top: 1.5rem; }
+.builder-actions, .player-actions { display: flex; flex-wrap: wrap; gap: .75rem; }
+.form-message { color: #ffd9a6; min-height: 1.5rem; }
+.session-plan { border-left: 2px solid var(--accent); list-style: none; margin: 1.5rem 0; padding-left: 1rem; }
+.session-plan li { display: flex; gap: .75rem; justify-content: space-between; padding: .55rem 0; }
+.session-plan time { color: var(--muted); white-space: nowrap; }
+.saved-box { border-top: 1px solid #494250; margin-top: 1.5rem; padding-top: 1.5rem; }
+.saved-box h3 { font-size: 1.05rem; }
+.player-shell { background: radial-gradient(circle at top, #56305d, #131116 62%); inset: 0; min-height: 100vh; overflow-y: auto; padding: 5rem 0; position: fixed; z-index: 3000; }
+.player-content { max-width: 760px; text-align: center; }
+.current-step { font-size: clamp(1.25rem, 3vw, 1.8rem); margin: 3rem auto 1rem; max-width: 38rem; min-height: 5rem; }
+.timer { font-size: clamp(4rem, 14vw, 8rem); font-variant-numeric: tabular-nums; font-weight: 300; letter-spacing: -.05em; }
+.player-shell .progress { background: #322d38; height: .5rem; margin: 2rem auto; max-width: 36rem; }
+.player-shell .progress-bar { background: var(--accent); }
+.player-actions { justify-content: center; }
+.player-actions .btn-link { color: #dfb8e6; }
+.player-note { font-size: .9rem; margin: 2rem auto 0; max-width: 36rem; }
+body.session-active { overflow: hidden; }
+@media (max-width: 800px) {
+  .builder-layout { grid-template-columns: 1fr; }
+  .preview-panel { position: static; }
+}
+@media (max-width: 560px) {
+  .builder-row, .segment-options { grid-template-columns: 1fr; }
+  .builder-hero { padding: 3.5rem 0 3rem; }
+}
+

--- a/meditation/builder.html
+++ b/meditation/builder.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Meditation Builder | ChessJitsu.net</title>
+  <meta name="description" content="Create and play a personalized guided meditation session in your browser.">
+  <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/meditation/meditation.css" rel="stylesheet">
+  <link href="/meditation/builder.css" rel="stylesheet">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <script src="/vendor/jquery/jquery.min.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to meditation builder</a>
+  <div id="navbar_container"></div>
+
+  <header class="builder-hero">
+    <div class="container">
+      <p class="eyebrow">ChessJitsu Meditation Builder</p>
+      <h1>Build a practice for this moment.</h1>
+      <p>Choose your intention and the steps that feel useful. Your session stays private in this browser.</p>
+    </div>
+  </header>
+
+  <main id="main-content" class="container builder-layout" tabindex="-1">
+    <form id="builder-form" class="builder-panel" aria-labelledby="builder-heading">
+      <h2 id="builder-heading">Design your session</h2>
+
+      <div class="form-group">
+        <label for="session-name">Session name</label>
+        <input class="form-control" id="session-name" maxlength="60" value="My meditation">
+      </div>
+
+      <div class="builder-row">
+        <div class="form-group">
+          <label for="intention">Intention</label>
+          <select class="form-control" id="intention">
+            <option value="calm">Calm</option>
+            <option value="focus">Focus</option>
+            <option value="confidence">Confidence</option>
+            <option value="recovery">Recovery</option>
+            <option value="sleep">Rest and sleep</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="session-length">Length</label>
+          <select class="form-control" id="session-length">
+            <option value="5">5 minutes</option>
+            <option value="10" selected>10 minutes</option>
+            <option value="15">15 minutes</option>
+            <option value="20">20 minutes</option>
+          </select>
+        </div>
+      </div>
+
+      <fieldset>
+        <legend>Choose your steps</legend>
+        <p class="field-help">The time is divided evenly across the steps you select.</p>
+        <div id="segment-options" class="segment-options">
+          <label><input type="checkbox" value="arrive" checked> <span><strong>Arrive</strong><small>Settle into your posture and the present moment.</small></span></label>
+          <label><input type="checkbox" value="breathe" checked> <span><strong>Breathing</strong><small>Follow an easy, natural rhythm.</small></span></label>
+          <label><input type="checkbox" value="body" checked> <span><strong>Body scan</strong><small>Notice sensation without needing to change it.</small></span></label>
+          <label><input type="checkbox" value="visualize"> <span><strong>Visualization</strong><small>Picture the quality you want to carry forward.</small></span></label>
+          <label><input type="checkbox" value="silence" checked> <span><strong>Quiet space</strong><small>Practice in silence between gentle bells.</small></span></label>
+          <label><input type="checkbox" value="close" checked> <span><strong>Closing</strong><small>Return attention and finish with intention.</small></span></label>
+        </div>
+      </fieldset>
+
+      <div class="builder-row settings-row">
+        <div class="form-group">
+          <label for="voice-setting">Guidance</label>
+          <select class="form-control" id="voice-setting">
+            <option value="spoken">Spoken prompts</option>
+            <option value="text">On-screen prompts only</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="ambience">Ambience</label>
+          <select class="form-control" id="ambience">
+            <option value="none">None</option>
+            <option value="soft">Soft air</option>
+            <option value="deep">Deep hum</option>
+          </select>
+        </div>
+      </div>
+
+      <p id="form-message" class="form-message" role="alert"></p>
+      <div class="builder-actions">
+        <button class="btn btn-meditation" type="submit">Build session</button>
+        <button class="btn btn-outline-light" id="save-session" type="button">Save on this device</button>
+      </div>
+    </form>
+
+    <aside class="preview-panel" aria-labelledby="preview-heading">
+      <p class="eyebrow">Session preview</p>
+      <h2 id="preview-heading">My meditation</h2>
+      <p id="preview-summary">10 minutes for calm</p>
+      <ol id="session-plan" class="session-plan"></ol>
+      <div class="saved-box">
+        <h3>Saved session</h3>
+        <p id="saved-status">Nothing saved on this device yet.</p>
+        <button class="btn btn-sm btn-outline-light" id="load-session" type="button" hidden>Load saved session</button>
+      </div>
+    </aside>
+  </main>
+
+  <section id="player" class="player-shell" aria-labelledby="player-title" hidden>
+    <div class="container player-content">
+      <p class="eyebrow">Now practicing</p>
+      <h2 id="player-title">My meditation</h2>
+      <p id="current-step" class="current-step" aria-live="polite">Ready when you are.</p>
+      <div id="timer" class="timer" role="timer" aria-label="Time remaining">10:00</div>
+      <div class="progress" aria-hidden="true"><div id="session-progress" class="progress-bar"></div></div>
+      <div class="player-actions">
+        <button class="btn btn-meditation" id="play-pause" type="button">Start session</button>
+        <button class="btn btn-outline-light" id="restart-session" type="button">Restart</button>
+        <button class="btn btn-link" id="close-player" type="button">Return to builder</button>
+      </div>
+      <p class="player-note">Keep this tab open while the session is playing. Spoken prompts depend on voice support in your browser.</p>
+    </div>
+  </section>
+
+  <footer class="site-footer"><div class="container"><p class="mb-0">Copyright &copy; ChessJitsu.net 2026</p></div></footer>
+  <script>$(function () { $('#navbar_container').load('/navbar.html'); });</script>
+  <script src="/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="/meditation/builder.js"></script>
+</body>
+</html>
+

--- a/meditation/builder.js
+++ b/meditation/builder.js
@@ -1,0 +1,265 @@
+(function () {
+  'use strict';
+
+  const segmentCopy = {
+    arrive: { name: 'Arrive', prompts: { calm: 'Let the day soften around you. Notice the support beneath your body.', focus: 'Let your attention gather here. This moment is the only task.', confidence: 'Take your place in this moment. You do not need to shrink.', recovery: 'Allow yourself to arrive without asking anything more of your body.', sleep: 'Let the day begin to loosen its hold.' } },
+    breathe: { name: 'Breathing', prompts: { calm: 'Breathe in gently. Breathe out a little more slowly.', focus: 'Follow one complete breath from beginning to end.', confidence: 'Breathe in steadiness. Breathe out unnecessary tension.', recovery: 'Let each breath create a little more room.', sleep: 'Allow the breath to become quiet, easy, and unforced.' } },
+    body: { name: 'Body scan', prompts: { calm: 'Notice where the body is already at ease, then soften around the edges of tension.', focus: 'Move attention slowly through the body, noticing clear physical sensation.', confidence: 'Feel the strength and support present in your body.', recovery: 'Listen to the body with patience, without trying to fix what you find.', sleep: 'Soften the forehead, jaw, shoulders, hands, and belly.' } },
+    visualize: { name: 'Visualization', prompts: { calm: 'Picture still water. Let each thought pass across the surface and move on.', focus: 'Picture one clear path in front of you and the next simple step upon it.', confidence: 'Imagine meeting the next challenge with a steady breath and an open posture.', recovery: 'Picture warmth moving toward the places that need care.', sleep: 'Imagine the room becoming quieter and darker with every breath.' } },
+    silence: { name: 'Quiet space', prompts: { calm: 'Rest in quiet. Nothing needs to be solved right now.', focus: 'Stay with the breath. When attention wanders, return without judgment.', confidence: 'Sit with your own presence. Let steadiness speak for itself.', recovery: 'Give the body and mind this quiet space to restore.', sleep: 'Rest in the quiet between thoughts.' } },
+    close: { name: 'Closing', prompts: { calm: 'Notice what has softened. Carry one small piece of this calm with you.', focus: 'Choose the one thing that deserves your attention next.', confidence: 'Remember this steadiness is available each time you return to your breath.', recovery: 'Thank yourself for making room to pause and listen.', sleep: 'Release the practice and allow rest to continue in its own way.' } }
+  };
+
+  const form = document.querySelector('#builder-form');
+  const nameInput = document.querySelector('#session-name');
+  const intentionInput = document.querySelector('#intention');
+  const lengthInput = document.querySelector('#session-length');
+  const voiceInput = document.querySelector('#voice-setting');
+  const ambienceInput = document.querySelector('#ambience');
+  const optionInputs = Array.from(document.querySelectorAll('#segment-options input'));
+  const planList = document.querySelector('#session-plan');
+  const previewHeading = document.querySelector('#preview-heading');
+  const previewSummary = document.querySelector('#preview-summary');
+  const formMessage = document.querySelector('#form-message');
+  const player = document.querySelector('#player');
+  const playerTitle = document.querySelector('#player-title');
+  const currentStep = document.querySelector('#current-step');
+  const timer = document.querySelector('#timer');
+  const progress = document.querySelector('#session-progress');
+  const playPause = document.querySelector('#play-pause');
+  const restartButton = document.querySelector('#restart-session');
+  const closeButton = document.querySelector('#close-player');
+  const savedStatus = document.querySelector('#saved-status');
+  const loadButton = document.querySelector('#load-session');
+
+  let session = null;
+  let elapsed = 0;
+  let intervalId = null;
+  let activeSegment = -1;
+  let audioContext = null;
+  let ambienceNodes = [];
+
+  function selectedSegments() {
+    return optionInputs.filter(input => input.checked).map(input => input.value);
+  }
+
+  function buildSession() {
+    const segments = selectedSegments();
+    if (!segments.length) return null;
+    const totalSeconds = Number(lengthInput.value) * 60;
+    const base = Math.floor(totalSeconds / segments.length);
+    let used = 0;
+    const steps = segments.map((key, index) => {
+      const seconds = index === segments.length - 1 ? totalSeconds - used : base;
+      used += seconds;
+      return { key, seconds, name: segmentCopy[key].name, prompt: segmentCopy[key].prompts[intentionInput.value] };
+    });
+    return { name: nameInput.value.trim() || 'My meditation', intention: intentionInput.value, minutes: Number(lengthInput.value), voice: voiceInput.value, ambience: ambienceInput.value, steps };
+  }
+
+  function durationLabel(seconds) {
+    const minutes = Math.floor(seconds / 60);
+    const remainder = seconds % 60;
+    return remainder ? `${minutes}:${String(remainder).padStart(2, '0')}` : `${minutes} min`;
+  }
+
+  function renderPreview() {
+    const draft = buildSession();
+    previewHeading.textContent = nameInput.value.trim() || 'My meditation';
+    previewSummary.textContent = `${lengthInput.value} minutes for ${intentionInput.options[intentionInput.selectedIndex].text.toLowerCase()}`;
+    planList.innerHTML = '';
+    if (!draft) {
+      planList.innerHTML = '<li>Select at least one step to build a session.</li>';
+      return;
+    }
+    draft.steps.forEach(step => {
+      const item = document.createElement('li');
+      item.innerHTML = `<span>${step.name}</span><time>${durationLabel(step.seconds)}</time>`;
+      planList.appendChild(item);
+    });
+  }
+
+  function formatTimer(seconds) {
+    return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}`;
+  }
+
+  function speak(text) {
+    if (!session || session.voice !== 'spoken' || !('speechSynthesis' in window)) return;
+    window.speechSynthesis.cancel();
+    const message = new SpeechSynthesisUtterance(text);
+    message.rate = 0.82;
+    message.pitch = 0.95;
+    window.speechSynthesis.speak(message);
+  }
+
+  function ensureAudio() {
+    if (!audioContext) audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    if (audioContext.state === 'suspended') audioContext.resume();
+  }
+
+  function bell() {
+    ensureAudio();
+    const oscillator = audioContext.createOscillator();
+    const gain = audioContext.createGain();
+    oscillator.frequency.setValueAtTime(528, audioContext.currentTime);
+    oscillator.frequency.exponentialRampToValueAtTime(264, audioContext.currentTime + 2.2);
+    gain.gain.setValueAtTime(0.0001, audioContext.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.18, audioContext.currentTime + 0.03);
+    gain.gain.exponentialRampToValueAtTime(0.0001, audioContext.currentTime + 2.5);
+    oscillator.connect(gain).connect(audioContext.destination);
+    oscillator.start();
+    oscillator.stop(audioContext.currentTime + 2.6);
+  }
+
+  function startAmbience() {
+    stopAmbience();
+    if (!session || session.ambience === 'none') return;
+    ensureAudio();
+    const oscillator = audioContext.createOscillator();
+    const gain = audioContext.createGain();
+    oscillator.type = session.ambience === 'deep' ? 'sine' : 'triangle';
+    oscillator.frequency.value = session.ambience === 'deep' ? 72 : 118;
+    gain.gain.value = session.ambience === 'deep' ? 0.025 : 0.012;
+    oscillator.connect(gain).connect(audioContext.destination);
+    oscillator.start();
+    ambienceNodes = [oscillator, gain];
+  }
+
+  function stopAmbience() {
+    if (ambienceNodes[0]) {
+      try { ambienceNodes[0].stop(); } catch (error) { /* already stopped */ }
+    }
+    ambienceNodes = [];
+  }
+
+  function stepAt(second) {
+    let boundary = 0;
+    for (let index = 0; index < session.steps.length; index += 1) {
+      boundary += session.steps[index].seconds;
+      if (second < boundary) return index;
+    }
+    return session.steps.length - 1;
+  }
+
+  function updatePlayer() {
+    const total = session.minutes * 60;
+    const remaining = Math.max(0, total - elapsed);
+    timer.textContent = formatTimer(remaining);
+    progress.style.width = `${Math.min(100, (elapsed / total) * 100)}%`;
+    const index = stepAt(elapsed);
+    if (index !== activeSegment) {
+      activeSegment = index;
+      const step = session.steps[index];
+      currentStep.textContent = step.prompt;
+      bell();
+      window.setTimeout(() => speak(step.prompt), 900);
+    }
+    if (remaining === 0) finishSession();
+  }
+
+  function startSession() {
+    if (intervalId) return;
+    ensureAudio();
+    startAmbience();
+    playPause.textContent = 'Pause';
+    updatePlayer();
+    intervalId = window.setInterval(() => { elapsed += 1; updatePlayer(); }, 1000);
+  }
+
+  function pauseSession() {
+    window.clearInterval(intervalId);
+    intervalId = null;
+    stopAmbience();
+    if ('speechSynthesis' in window) window.speechSynthesis.cancel();
+    playPause.textContent = 'Continue';
+  }
+
+  function finishSession() {
+    pauseSession();
+    bell();
+    currentStep.textContent = 'Your session is complete. Take your time returning.';
+    playPause.textContent = 'Practice again';
+    elapsed = session.minutes * 60;
+  }
+
+  function resetPlayer() {
+    pauseSession();
+    elapsed = 0;
+    activeSegment = -1;
+    timer.textContent = formatTimer(session.minutes * 60);
+    progress.style.width = '0%';
+    currentStep.textContent = 'Ready when you are.';
+    playPause.textContent = 'Start session';
+  }
+
+  function openPlayer() {
+    playerTitle.textContent = session.name;
+    resetPlayer();
+    player.hidden = false;
+    document.body.classList.add('session-active');
+    playPause.focus();
+  }
+
+  function closePlayer() {
+    pauseSession();
+    player.hidden = true;
+    document.body.classList.remove('session-active');
+    form.querySelector('button[type="submit"]').focus();
+  }
+
+  form.addEventListener('input', renderPreview);
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+    session = buildSession();
+    if (!session) {
+      formMessage.textContent = 'Choose at least one step for your session.';
+      return;
+    }
+    formMessage.textContent = '';
+    openPlayer();
+  });
+
+  playPause.addEventListener('click', () => {
+    if (elapsed >= session.minutes * 60) resetPlayer();
+    intervalId ? pauseSession() : startSession();
+  });
+  restartButton.addEventListener('click', resetPlayer);
+  closeButton.addEventListener('click', closePlayer);
+
+  document.querySelector('#save-session').addEventListener('click', () => {
+    const draft = buildSession();
+    if (!draft) {
+      formMessage.textContent = 'Choose at least one step before saving.';
+      return;
+    }
+    localStorage.setItem('chessjitsuMeditation', JSON.stringify(draft));
+    formMessage.textContent = 'Session saved on this device.';
+    refreshSavedStatus();
+  });
+
+  function refreshSavedStatus() {
+    const saved = localStorage.getItem('chessjitsuMeditation');
+    if (!saved) return;
+    const data = JSON.parse(saved);
+    savedStatus.textContent = `${data.name} — ${data.minutes} minutes for ${data.intention}`;
+    loadButton.hidden = false;
+  }
+
+  loadButton.addEventListener('click', () => {
+    const data = JSON.parse(localStorage.getItem('chessjitsuMeditation'));
+    nameInput.value = data.name;
+    intentionInput.value = data.intention;
+    lengthInput.value = String(data.minutes);
+    voiceInput.value = data.voice;
+    ambienceInput.value = data.ambience;
+    const keys = data.steps.map(step => step.key);
+    optionInputs.forEach(input => { input.checked = keys.includes(input.value); });
+    formMessage.textContent = 'Saved session loaded.';
+    renderPreview();
+    form.scrollIntoView({ behavior: 'smooth' });
+  });
+
+  renderPreview();
+  refreshSavedStatus();
+}());
+

--- a/meditation/index.html
+++ b/meditation/index.html
@@ -21,6 +21,12 @@
     </div>
   </header>
   <main id="main-content" class="container" tabindex="-1">
+    <section class="watch-notes" aria-labelledby="build-heading">
+      <p class="eyebrow">Create your own</p>
+      <h2 id="build-heading">Build a meditation for this moment</h2>
+      <p>Choose an intention, session length, guided steps, voice prompts, and ambience. No account is required, and saved sessions stay on your device.</p>
+      <a class="btn btn-meditation" href="/meditation/builder.html">Open Meditation Builder</a>
+    </section>
     <h2 class="sr-only">Meditation practices</h2>
     <div class="practice-grid">
       <article class="practice-card">

--- a/navbar.html
+++ b/navbar.html
@@ -11,6 +11,7 @@
         <li class="nav-item"><a class="nav-link" href="/articles">Articles</a></li>
         <li class="nav-item"><a class="nav-link" href="/apps">Quotes</a></li>
         <li class="nav-item"><a class="nav-link" href="/meditation/">Meditation</a></li>
+        <li class="nav-item"><a class="nav-link" href="/meditation/builder.html">Meditation Builder</a></li>
         <li class="nav-item"><a class="nav-link" href="https://www.youtube.com/@ChessJitsu" target="_blank" rel="noopener">YouTube<span class="sr-only"> (opens in a new tab)</span></a></li>
         <li class="nav-item"><a class="nav-link" href="https://www.teepublic.com/user/paradoxbjj" target="_blank" rel="noopener">Shop<span class="sr-only"> (opens in a new tab)</span></a></li>
         <li class="nav-item"><a class="nav-link" href="/contact">Contact</a></li>


### PR DESCRIPTION
## What changed

- adds a Meditation Builder page linked from the primary navbar and meditation hub
- lets visitors choose a session name, intention, length, guided steps, guidance mode, and ambience
- generates a timed session plan and runs it in a distraction-free player
- provides optional browser-spoken prompts, generated bells, and lightweight generated ambience
- supports pause, continue, restart, progress, and locally saved session settings
- keeps saved data on the visitor's device with no account or server required
- includes keyboard focus, live status announcements, semantic controls, responsive layout, and reduced-motion support

## Why

This is the first self-contained version of a tool that lets ChessJitsu visitors assemble personal meditation sessions similar to the curated practices already on the site, without introducing hosting costs or user-account complexity.

## Validation

- JavaScript syntax check passed
- all five meditation HTML pages parsed successfully
- builder navigation, form, preview, timer, local save, voice, audio, and session clock hooks were verified
- existing meditation video IDs and the 1:57 start time remain intact