### PR TITLE
Rename meditation navbar labels

### DIFF
--- a/navbar.html
+++ b/navbar.html
@@ -8,8 +8,8 @@
     <div class="collapse navbar-collapse" id="navbarResponsive">
       <ul class="navbar-nav ml-auto">
         <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
-        <li class="nav-item"><a class="nav-link" href="/meditation/">Meditation</a></li>
-        <li class="nav-item"><a class="nav-link" href="/meditation/builder.html">Meditation Builder</a></li>
+        <li class="nav-item"><a class="nav-link" href="/meditation/">Chess Meditation</a></li>
+        <li class="nav-item"><a class="nav-link" href="/meditation/builder.html">Chess Meditation Builder</a></li>
         <li class="nav-item"><a class="nav-link" href="/contact">Contact</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## What changed

- renames `Meditation` to `Chess Meditation`
- renames `Meditation Builder` to `Chess Meditation Builder`
- preserves both existing destination URLs

## Why

The new labels connect the meditation experience more clearly to the ChessJitsu identity.

## Validation

Confirmed both new labels appear, the old labels are absent, and the links remain unchanged.