### PR TITLE
Add prompt-based Chess Meditation Builder

### DIFF
--- a/meditation/builder.css
+++ b/meditation/builder.css
@@ -3,6 +3,9 @@
 .builder-hero > .container > p:last-child { color: var(--muted); font-size: 1.1rem; margin: 1rem auto 0; max-width: 42rem; }
 .builder-layout { display: grid; gap: 2rem; grid-template-columns: minmax(0, 1.5fr) minmax(280px, .8fr); padding-bottom: 4rem; padding-top: 4rem; }
 .builder-panel, .preview-panel { background: var(--card); border: 1px solid #403a48; border-radius: .85rem; padding: clamp(1.25rem, 3vw, 2rem); }
+.prompt-builder { background: linear-gradient(135deg, #1b1920, #332437); border: 1px solid #5c4661; border-radius: .75rem; margin: 1.5rem 0 2rem; padding: 1.25rem; }
+.prompt-builder h3 { font-size: 1.2rem; margin-top: 0; }
+.prompt-builder textarea { margin-bottom: 1rem; resize: vertical; }
 .preview-panel { align-self: start; position: sticky; top: 5rem; }
 .builder-row { display: grid; gap: 1rem; grid-template-columns: 1fr 1fr; }
 .builder-panel label, .builder-panel legend { color: var(--ink); font-weight: 700; }
@@ -15,6 +18,7 @@
 .segment-options span { display: grid; }
 .segment-options small { font-weight: 400; }
 .settings-row { margin-top: 1.5rem; }
+.voice-preference { margin-top: .5rem; }
 .builder-actions, .player-actions { display: flex; flex-wrap: wrap; gap: .75rem; }
 .form-message { color: #ffd9a6; min-height: 1.5rem; }
 .session-plan { border-left: 2px solid var(--accent); list-style: none; margin: 1.5rem 0; padding-left: 1rem; }

--- a/meditation/builder.html
+++ b/meditation/builder.html
@@ -27,6 +27,14 @@
     <form id="builder-form" class="builder-panel" aria-labelledby="builder-heading">
       <h2 id="builder-heading">Design your session</h2>
 
+      <section class="prompt-builder" aria-labelledby="prompt-heading">
+        <h3 id="prompt-heading">Describe the meditation you want</h3>
+        <p class="field-help">Include a length, intention, and any steps you prefer. You can adjust everything afterward.</p>
+        <label for="meditation-prompt">Your meditation prompt</label>
+        <textarea class="form-control" id="meditation-prompt" rows="4" placeholder="Create a 15-minute meditation for confidence before a chess tournament, with breathing, visualization, and a quiet ending."></textarea>
+        <button class="btn btn-meditation" id="create-from-prompt" type="button">Create from prompt</button>
+      </section>
+
       <div class="form-group">
         <label for="session-name">Session name</label>
         <input class="form-control" id="session-name" maxlength="60" value="My meditation">
@@ -83,6 +91,15 @@
             <option value="deep">Deep hum</option>
           </select>
         </div>
+      </div>
+
+      <div class="form-group voice-preference">
+        <label for="voice-choice">Narrator voice</label>
+        <select class="form-control" id="voice-choice">
+          <option value="auto">Prefer a Latin American Spanish feminine voice</option>
+          <option value="default">Use this device’s default voice</option>
+        </select>
+        <small id="voice-status">Checking the voices available on this device…</small>
       </div>
 
       <p id="form-message" class="form-message" role="alert"></p>

--- a/meditation/builder.js
+++ b/meditation/builder.js
@@ -11,11 +11,15 @@
   };
 
   const form = document.querySelector('#builder-form');
+  const promptInput = document.querySelector('#meditation-prompt');
+  const promptButton = document.querySelector('#create-from-prompt');
   const nameInput = document.querySelector('#session-name');
   const intentionInput = document.querySelector('#intention');
   const lengthInput = document.querySelector('#session-length');
   const voiceInput = document.querySelector('#voice-setting');
   const ambienceInput = document.querySelector('#ambience');
+  const voiceChoice = document.querySelector('#voice-choice');
+  const voiceStatus = document.querySelector('#voice-status');
   const optionInputs = Array.from(document.querySelectorAll('#segment-options input'));
   const planList = document.querySelector('#session-plan');
   const previewHeading = document.querySelector('#preview-heading');
@@ -38,6 +42,86 @@
   let activeSegment = -1;
   let audioContext = null;
   let ambienceNodes = [];
+  let availableVoices = [];
+
+  const latinVoicePattern = /^es-(MX|US|419|AR|BO|CL|CO|CR|CU|DO|EC|GT|HN|NI|PA|PE|PR|PY|SV|UY|VE)/i;
+  const feminineNamePattern = /(dalia|sabina|paulina|paloma|luciana|elena|sofia|maria|monica|rosa|laura|isabela|female|mujer)/i;
+
+  function preferredLatinVoice() {
+    const latinVoices = availableVoices.filter(voice => latinVoicePattern.test(voice.lang));
+    return latinVoices.find(voice => feminineNamePattern.test(voice.name)) || latinVoices[0] || null;
+  }
+
+  function selectedVoice() {
+    if (voiceChoice.value === 'default') return null;
+    if (voiceChoice.value !== 'auto') return availableVoices.find(voice => voice.voiceURI === voiceChoice.value) || null;
+    return preferredLatinVoice();
+  }
+
+  function refreshVoices() {
+    if (!('speechSynthesis' in window)) {
+      voiceStatus.textContent = 'Spoken narration is not supported by this browser. On-screen prompts will still work.';
+      return;
+    }
+    availableVoices = window.speechSynthesis.getVoices();
+    const existing = new Set(Array.from(voiceChoice.options).map(option => option.value));
+    availableVoices.filter(voice => latinVoicePattern.test(voice.lang)).forEach(voice => {
+      if (existing.has(voice.voiceURI)) return;
+      const option = document.createElement('option');
+      option.value = voice.voiceURI;
+      option.textContent = `${voice.name} — ${voice.lang}`;
+      voiceChoice.appendChild(option);
+    });
+    const preferred = preferredLatinVoice();
+    voiceStatus.textContent = preferred
+      ? `Preferred device voice: ${preferred.name} (${preferred.lang}). Voice quality varies by device.`
+      : 'No Latin American Spanish voice was found. The device default voice will be used.';
+  }
+
+  function interpretPrompt() {
+    const text = promptInput.value.trim();
+    if (!text) {
+      formMessage.textContent = 'Describe the meditation you want first.';
+      promptInput.focus();
+      return;
+    }
+    const lower = text.toLowerCase();
+    const duration = lower.match(/(\d{1,2})\s*(?:minute|minuto|minutos|min)\b/);
+    if (duration) {
+      const requested = Number(duration[1]);
+      const allowed = [5, 10, 15, 20];
+      lengthInput.value = String(allowed.reduce((best, value) => Math.abs(value - requested) < Math.abs(best - requested) ? value : best));
+    }
+    const intentionRules = [
+      ['sleep', /(sleep|bedtime|rest|insomnia|dormir|sueño|descanso)/],
+      ['confidence', /(confidence|courage|brave|competition|tournament|confianza|valor|torneo)/],
+      ['focus', /(focus|concentrat|study|work|chess|enfoque|concentración|ajedrez)/],
+      ['recovery', /(recover|healing|pain|training|workout|recuper|sanar|dolor)/],
+      ['calm', /(calm|anxiety|stress|relax|peace|tranquil|ansiedad|estrés|paz)/]
+    ];
+    const matchedIntention = intentionRules.find(rule => rule[1].test(lower));
+    if (matchedIntention) intentionInput.value = matchedIntention[0];
+
+    const segmentRules = {
+      arrive: /(arrive|ground|settle|present|llegar|presente)/,
+      breathe: /(breath|breathing|respira|respiración)/,
+      body: /(body|scan|muscle|cuerpo|escaneo)/,
+      visualize: /(visual|imagine|picture|visualiza|imagina)/,
+      silence: /(silence|quiet|pause|silencio|tranquil)/,
+      close: /(close|closing|ending|finish|cierre|final)/
+    };
+    const explicitSegments = Object.keys(segmentRules).filter(key => segmentRules[key].test(lower));
+    if (explicitSegments.length) optionInputs.forEach(input => { input.checked = explicitSegments.includes(input.value); });
+    if (/(no voice|silent guidance|text only|sin voz|solo texto)/.test(lower)) voiceInput.value = 'text';
+    else voiceInput.value = 'spoken';
+    if (/(no ambience|no background|sin ambiente|silence only)/.test(lower)) ambienceInput.value = 'none';
+    else if (/(deep|hum|grounding|grave|zumbido)/.test(lower)) ambienceInput.value = 'deep';
+    else if (/(ambience|background|soft|air|suave|ambiente)/.test(lower)) ambienceInput.value = 'soft';
+
+    nameInput.value = `${intentionInput.options[intentionInput.selectedIndex].text} meditation`;
+    formMessage.textContent = 'Your prompt has been turned into a session. Review or adjust the choices below.';
+    renderPreview();
+  }
 
   function selectedSegments() {
     return optionInputs.filter(input => input.checked).map(input => input.value);
@@ -54,7 +138,7 @@
       used += seconds;
       return { key, seconds, name: segmentCopy[key].name, prompt: segmentCopy[key].prompts[intentionInput.value] };
     });
-    return { name: nameInput.value.trim() || 'My meditation', intention: intentionInput.value, minutes: Number(lengthInput.value), voice: voiceInput.value, ambience: ambienceInput.value, steps };
+    return { name: nameInput.value.trim() || 'My meditation', intention: intentionInput.value, minutes: Number(lengthInput.value), voice: voiceInput.value, voiceId: voiceChoice.value, ambience: ambienceInput.value, steps };
   }
 
   function durationLabel(seconds) {
@@ -89,6 +173,11 @@
     const message = new SpeechSynthesisUtterance(text);
     message.rate = 0.82;
     message.pitch = 0.95;
+    const narrator = selectedVoice();
+    if (narrator) {
+      message.voice = narrator;
+      message.lang = narrator.lang;
+    }
     window.speechSynthesis.speak(message);
   }
 
@@ -208,6 +297,7 @@
   }
 
   form.addEventListener('input', renderPreview);
+  promptButton.addEventListener('click', interpretPrompt);
   form.addEventListener('submit', event => {
     event.preventDefault();
     session = buildSession();
@@ -251,6 +341,7 @@
     intentionInput.value = data.intention;
     lengthInput.value = String(data.minutes);
     voiceInput.value = data.voice;
+    voiceChoice.value = data.voiceId || 'auto';
     ambienceInput.value = data.ambience;
     const keys = data.steps.map(step => step.key);
     optionInputs.forEach(input => { input.checked = keys.includes(input.value); });
@@ -261,5 +352,7 @@
 
   renderPreview();
   refreshSavedStatus();
+  refreshVoices();
+  if ('speechSynthesis' in window) window.speechSynthesis.onvoiceschanged = refreshVoices;
 }());
 


### PR DESCRIPTION
## What changed

- adds a plain-language prompt box above the existing manual builder
- interprets requested duration, intention, meditation steps, ambience, and spoken-versus-text guidance
- recognizes common English and Spanish prompt keywords
- keeps every generated choice editable through the existing controls
- prefers a Latin American Spanish device voice when one is available
- lists compatible Latin American voices installed on the visitor's device
- clearly falls back to the device default voice when a preferred voice is unavailable
- saves the selected voice preference with the local session

## Why

Visitors can describe the meditation they want in natural language and receive an immediately usable session without learning every control first. This version remains free, private, and browser-based with no API key or server cost.

## Validation

- JavaScript syntax check passed
- builder page structure and prompt controls parsed successfully
- prompt interpreter and Latin American voice-selection hooks were verified
- existing form, preview, timer, local save, generated audio, and session clock remain present