### PR TITLE
Add interactive Chess.com puzzle section

### DIFF
--- a/navbar.html
+++ b/navbar.html
@@ -10,6 +10,7 @@
         <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
         <li class="nav-item"><a class="nav-link" href="/meditation/">Chess Meditation</a></li>
         <li class="nav-item"><a class="nav-link" href="/meditation/builder.html">Chess Meditation Builder</a></li>
+        <li class="nav-item"><a class="nav-link" href="/puzzles/">Chess Puzzles</a></li>
         <li class="nav-item"><a class="nav-link" href="/contact">Contact</a></li>
       </ul>
     </div>

--- a/puzzles/index.html
+++ b/puzzles/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Chess Puzzles | ChessJitsu.net</title>
+  <meta name="description" content="Solve today's Chess.com Daily Puzzle or practice with a random archived puzzle on ChessJitsu.net.">
+  <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/puzzles/puzzles.css" rel="stylesheet">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <script src="/vendor/jquery/jquery.min.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to chess puzzle</a>
+  <div id="navbar_container"></div>
+
+  <header class="puzzle-hero">
+    <div class="container">
+      <p class="eyebrow">ChessJitsu Training</p>
+      <h1>Chess Puzzles</h1>
+      <p>Slow down, calculate clearly, and find the strongest continuation.</p>
+    </div>
+  </header>
+
+  <main id="main-content" class="container puzzle-layout" tabindex="-1">
+    <section class="puzzle-workspace" aria-labelledby="puzzle-title">
+      <div class="mode-switcher" aria-label="Choose puzzle mode">
+        <button class="btn btn-puzzle" id="daily-puzzle" type="button">Today’s Puzzle</button>
+        <button class="btn btn-outline-light" id="random-puzzle" type="button">Random Puzzle</button>
+      </div>
+
+      <div class="puzzle-heading">
+        <div><p class="eyebrow" id="puzzle-mode">Daily Puzzle</p><h2 id="puzzle-title">Loading puzzle…</h2></div>
+        <p id="side-to-move" class="side-to-move"></p>
+      </div>
+
+      <div id="chessboard" class="chessboard" role="grid" aria-label="Interactive chess puzzle board" aria-busy="true"></div>
+      <p id="puzzle-feedback" class="puzzle-feedback" role="status" aria-live="polite">Loading from Chess.com…</p>
+
+      <div class="puzzle-controls">
+        <button class="btn btn-puzzle" id="hint-button" type="button" disabled>Hint</button>
+        <button class="btn btn-outline-light" id="restart-button" type="button" disabled>Restart</button>
+        <button class="btn btn-outline-light" id="solution-button" type="button" disabled>Show solution</button>
+      </div>
+
+      <p class="attribution"><a id="chess-credit" href="https://www.chess.com/puzzles" target="_blank" rel="noopener">Puzzle provided by Chess.com <span class="sr-only">(opens in a new tab)</span></a></p>
+    </section>
+
+    <aside class="puzzle-sidebar" aria-labelledby="progress-heading">
+      <h2 id="progress-heading">Your progress</h2>
+      <div class="stat-grid">
+        <div><strong id="daily-streak">0</strong><span>day streak</span></div>
+        <div><strong id="random-solved">0</strong><span>random solved</span></div>
+      </div>
+      <h3>How to play</h3>
+      <ol>
+        <li>Select the piece you want to move.</li>
+        <li>Select its destination square.</li>
+        <li>Continue until the full tactic is complete.</li>
+      </ol>
+      <p>Your progress is saved only on this device.</p>
+    </aside>
+  </main>
+
+  <footer class="site-footer"><div class="container"><p class="mb-0">Copyright &copy; ChessJitsu.net 2026</p></div></footer>
+  <script>$(function () { $('#navbar_container').load('/navbar.html'); });</script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.10.3/chess.min.js"></script>
+  <script src="/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="/puzzles/puzzles.js"></script>
+</body>
+</html>
+

--- a/puzzles/puzzles.css
+++ b/puzzles/puzzles.css
@@ -1,0 +1,41 @@
+:root { --ink: #f7f5f2; --muted: #c8c3cc; --surface: #17151b; --card: #24212a; --accent: #a978b1; --accent-dark: #6b3972; --light-square: #ddd3c5; --dark-square: #72537a; }
+body { background: var(--surface); color: var(--ink); line-height: 1.65; padding-top: 56px; }
+a { color: #dfb8e6; } a:hover { color: #fff; }
+.skip-link { background: #fff; color: #111; left: 1rem; padding: .75rem 1rem; position: fixed; top: -5rem; z-index: 2000; } .skip-link:focus { top: 1rem; }
+.puzzle-hero { background: linear-gradient(135deg, #17151b 15%, #56305d); padding: 4.5rem 0 3.5rem; text-align: center; }
+.puzzle-hero h1 { font-size: clamp(2.5rem, 7vw, 4.5rem); font-weight: 700; }
+.puzzle-hero > .container > p:last-child { color: var(--muted); font-size: 1.1rem; margin: 1rem auto 0; max-width: 40rem; }
+.eyebrow { color: #d8aee0; font-size: .82rem; font-weight: 700; letter-spacing: .12em; margin-bottom: .35rem; text-transform: uppercase; }
+.puzzle-layout { display: grid; gap: 2rem; grid-template-columns: minmax(0, 680px) minmax(250px, 1fr); padding-bottom: 4rem; padding-top: 4rem; }
+.puzzle-workspace, .puzzle-sidebar { background: var(--card); border: 1px solid #403a48; border-radius: .85rem; padding: clamp(1rem, 3vw, 2rem); }
+.puzzle-sidebar { align-self: start; position: sticky; top: 5rem; }
+.mode-switcher, .puzzle-controls { display: flex; flex-wrap: wrap; gap: .75rem; }
+.mode-switcher { margin-bottom: 2rem; }
+.btn-puzzle { background: var(--accent-dark); border: 1px solid var(--accent); color: #fff; }
+.btn-puzzle:hover, .btn-puzzle:focus { background: var(--accent); color: #111; }
+.puzzle-heading { align-items: end; display: flex; gap: 1rem; justify-content: space-between; }
+.puzzle-heading h2 { font-size: clamp(1.45rem, 4vw, 2rem); }
+.side-to-move { color: var(--muted); white-space: nowrap; }
+.chessboard { aspect-ratio: 1; border: 4px solid #443749; border-radius: .4rem; display: grid; grid-template-columns: repeat(8, 1fr); margin: 1.25rem auto; max-width: 620px; overflow: hidden; width: 100%; }
+.square { align-items: center; appearance: none; border: 0; border-radius: 0; color: #111; display: flex; font-family: "Segoe UI Symbol", "Arial Unicode MS", sans-serif; font-size: clamp(1.8rem, 7vw, 4.2rem); justify-content: center; line-height: 1; margin: 0; padding: 0; position: relative; }
+.square.light { background: var(--light-square); } .square.dark { background: var(--dark-square); }
+.square:hover { box-shadow: inset 0 0 0 4px rgba(255,255,255,.35); }
+.square:focus-visible { outline: 4px solid #ffd36a; outline-offset: -4px; z-index: 2; }
+.square.selected { box-shadow: inset 0 0 0 5px #ffd36a; }
+.square.hint-from { box-shadow: inset 0 0 0 5px #85d7ff; }
+.square.hint-to::after { background: rgba(40,170,95,.65); border-radius: 50%; content: ""; height: 28%; position: absolute; width: 28%; }
+.piece.black-piece { color: #161219; text-shadow: 0 1px 0 rgba(255,255,255,.35); }
+.piece.white-piece { color: #fff; text-shadow: 0 1px 2px #000, 0 0 1px #000; }
+.puzzle-feedback { background: #1b1920; border-left: 3px solid var(--accent); border-radius: 0 .4rem .4rem 0; min-height: 3.3rem; padding: .8rem 1rem; }
+.puzzle-feedback.success { border-left-color: #5fd58a; color: #bdf5cf; }
+.puzzle-feedback.error { border-left-color: #ff8c8c; color: #ffd0d0; }
+.attribution { margin: 1.5rem 0 0; text-align: center; }
+.stat-grid { display: grid; gap: .75rem; grid-template-columns: 1fr 1fr; margin: 1.5rem 0 2rem; }
+.stat-grid div { background: #1b1920; border-radius: .65rem; padding: 1rem; text-align: center; }
+.stat-grid strong { display: block; font-size: 2rem; } .stat-grid span, .puzzle-sidebar > p { color: var(--muted); }
+.puzzle-sidebar h3 { font-size: 1.15rem; }
+.puzzle-sidebar li + li { margin-top: .55rem; }
+.site-footer { background: #343a40; color: #fff; padding: 2rem 0; text-align: center; }
+@media (max-width: 900px) { .puzzle-layout { grid-template-columns: 1fr; } .puzzle-sidebar { position: static; } }
+@media (max-width: 520px) { .puzzle-heading { align-items: flex-start; flex-direction: column; } .square { font-size: clamp(1.8rem, 11vw, 3.4rem); } }
+

--- a/puzzles/puzzles.js
+++ b/puzzles/puzzles.js
@@ -1,0 +1,237 @@
+(function () {
+  'use strict';
+
+  const API = { daily: 'https://api.chess.com/pub/puzzle', random: 'https://api.chess.com/pub/puzzle/random' };
+  const pieces = { wp: '♙', wn: '♘', wb: '♗', wr: '♖', wq: '♕', wk: '♔', bp: '♟', bn: '♞', bb: '♝', br: '♜', bq: '♛', bk: '♚' };
+  const pieceNames = { p: 'pawn', n: 'knight', b: 'bishop', r: 'rook', q: 'queen', k: 'king' };
+  const board = document.querySelector('#chessboard');
+  const title = document.querySelector('#puzzle-title');
+  const modeLabel = document.querySelector('#puzzle-mode');
+  const sideLabel = document.querySelector('#side-to-move');
+  const feedback = document.querySelector('#puzzle-feedback');
+  const credit = document.querySelector('#chess-credit');
+  const hintButton = document.querySelector('#hint-button');
+  const restartButton = document.querySelector('#restart-button');
+  const solutionButton = document.querySelector('#solution-button');
+  const dailyButton = document.querySelector('#daily-puzzle');
+  const randomButton = document.querySelector('#random-puzzle');
+  const streakOutput = document.querySelector('#daily-streak');
+  const randomOutput = document.querySelector('#random-solved');
+
+  let puzzle = null;
+  let game = null;
+  let solution = [];
+  let solutionIndex = 0;
+  let selectedSquare = null;
+  let orientation = 'w';
+  let mode = 'daily';
+  let hintLevel = 0;
+  let locked = true;
+  let solutionTimer = null;
+
+  function setFeedback(message, type) {
+    feedback.textContent = message;
+    feedback.className = `puzzle-feedback${type ? ` ${type}` : ''}`;
+  }
+
+  function parseSolution(fen, pgn) {
+    const replay = new Chess(fen);
+    const clean = pgn
+      .replace(/\[[^\]]*\]/g, ' ')
+      .replace(/\{[^}]*\}/g, ' ')
+      .replace(/\([^)]*\)/g, ' ')
+      .replace(/\d+\.(?:\.\.)?/g, ' ');
+    const tokens = clean.split(/\s+/).filter(token => token && !/^(1-0|0-1|1\/2-1\/2|\*)$/.test(token));
+    const moves = [];
+    tokens.forEach(token => {
+      const move = replay.move(token, { sloppy: true });
+      if (move) moves.push(move);
+    });
+    return moves;
+  }
+
+  function boardSquares() {
+    const files = orientation === 'w' ? ['a','b','c','d','e','f','g','h'] : ['h','g','f','e','d','c','b','a'];
+    const ranks = orientation === 'w' ? [8,7,6,5,4,3,2,1] : [1,2,3,4,5,6,7,8];
+    return ranks.flatMap(rank => files.map(file => `${file}${rank}`));
+  }
+
+  function renderBoard() {
+    board.innerHTML = '';
+    boardSquares().forEach(squareName => {
+      const square = document.createElement('button');
+      const fileNumber = squareName.charCodeAt(0) - 96;
+      const rankNumber = Number(squareName[1]);
+      const piece = game.get(squareName);
+      square.type = 'button';
+      square.className = `square ${(fileNumber + rankNumber) % 2 ? 'light' : 'dark'}`;
+      square.dataset.square = squareName;
+      square.setAttribute('role', 'gridcell');
+      square.setAttribute('aria-label', piece ? `${squareName}, ${piece.color === 'w' ? 'white' : 'black'} ${pieceNames[piece.type]}` : `${squareName}, empty`);
+      if (squareName === selectedSquare) square.classList.add('selected');
+      if (hintLevel >= 1 && solution[solutionIndex] && squareName === solution[solutionIndex].from) square.classList.add('hint-from');
+      if (hintLevel >= 2 && solution[solutionIndex] && squareName === solution[solutionIndex].to) square.classList.add('hint-to');
+      if (piece) {
+        const span = document.createElement('span');
+        span.className = `piece ${piece.color === 'w' ? 'white-piece' : 'black-piece'}`;
+        span.setAttribute('aria-hidden', 'true');
+        span.textContent = pieces[`${piece.color}${piece.type}`];
+        square.appendChild(span);
+      }
+      square.addEventListener('click', () => chooseSquare(squareName));
+      board.appendChild(square);
+    });
+    board.setAttribute('aria-busy', 'false');
+  }
+
+  function chooseSquare(squareName) {
+    if (locked || !solution[solutionIndex]) return;
+    const piece = game.get(squareName);
+    if (!selectedSquare) {
+      if (!piece || piece.color !== game.turn()) {
+        setFeedback(`Choose a ${game.turn() === 'w' ? 'white' : 'black'} piece to move.`, 'error');
+        return;
+      }
+      selectedSquare = squareName;
+      hintLevel = 0;
+      renderBoard();
+      return;
+    }
+    if (piece && piece.color === game.turn()) {
+      selectedSquare = squareName;
+      renderBoard();
+      return;
+    }
+    const expected = solution[solutionIndex];
+    const attemptedFrom = selectedSquare;
+    selectedSquare = null;
+    if (attemptedFrom !== expected.from || squareName !== expected.to) {
+      hintLevel = 0;
+      setFeedback('That move is not the tactic. Take another look.', 'error');
+      renderBoard();
+      return;
+    }
+    game.move({ from: expected.from, to: expected.to, promotion: expected.promotion || 'q' });
+    solutionIndex += 1;
+    hintLevel = 0;
+    renderBoard();
+    if (solutionIndex >= solution.length) {
+      completePuzzle();
+      return;
+    }
+    locked = true;
+    setFeedback('Correct. Watch the reply…', 'success');
+    window.setTimeout(playReply, 650);
+  }
+
+  function playReply() {
+    const reply = solution[solutionIndex];
+    if (!reply) { completePuzzle(); return; }
+    game.move({ from: reply.from, to: reply.to, promotion: reply.promotion || 'q' });
+    solutionIndex += 1;
+    renderBoard();
+    if (solutionIndex >= solution.length) completePuzzle();
+    else { locked = false; setFeedback('Your move. Continue the tactic.'); }
+  }
+
+  function dateKey(timestamp) {
+    return new Date(timestamp * 1000).toISOString().slice(0, 10);
+  }
+
+  function completePuzzle() {
+    locked = true;
+    setFeedback('Puzzle solved! Excellent calculation.', 'success');
+    const progress = JSON.parse(localStorage.getItem('chessjitsuPuzzleProgress') || '{"streak":0,"lastDaily":"","randomSolved":0}');
+    if (mode === 'daily') {
+      const today = dateKey(puzzle.publish_time);
+      if (progress.lastDaily !== today) {
+        const previous = new Date(`${today}T00:00:00Z`);
+        previous.setUTCDate(previous.getUTCDate() - 1);
+        progress.streak = progress.lastDaily === previous.toISOString().slice(0, 10) ? progress.streak + 1 : 1;
+        progress.lastDaily = today;
+      }
+    } else {
+      progress.randomSolved += 1;
+    }
+    localStorage.setItem('chessjitsuPuzzleProgress', JSON.stringify(progress));
+    renderProgress();
+  }
+
+  function renderProgress() {
+    const progress = JSON.parse(localStorage.getItem('chessjitsuPuzzleProgress') || '{"streak":0,"lastDaily":"","randomSolved":0}');
+    streakOutput.textContent = progress.streak || 0;
+    randomOutput.textContent = progress.randomSolved || 0;
+  }
+
+  function restartPuzzle() {
+    window.clearTimeout(solutionTimer);
+    game = new Chess(puzzle.fen);
+    solutionIndex = 0;
+    selectedSquare = null;
+    hintLevel = 0;
+    locked = false;
+    renderBoard();
+    setFeedback(`${orientation === 'w' ? 'White' : 'Black'} to move. Find the best continuation.`);
+  }
+
+  function showSolution() {
+    locked = true;
+    selectedSquare = null;
+    setFeedback('Showing the solution…');
+    function next() {
+      const move = solution[solutionIndex];
+      if (!move) { setFeedback('Solution complete. Restart to try it yourself.', 'success'); return; }
+      game.move({ from: move.from, to: move.to, promotion: move.promotion || 'q' });
+      solutionIndex += 1;
+      renderBoard();
+      solutionTimer = window.setTimeout(next, 650);
+    }
+    next();
+  }
+
+  async function loadPuzzle(nextMode) {
+    mode = nextMode;
+    locked = true;
+    board.setAttribute('aria-busy', 'true');
+    title.textContent = 'Loading puzzle…';
+    modeLabel.textContent = mode === 'daily' ? 'Daily Puzzle' : 'Random Puzzle';
+    setFeedback('Loading from Chess.com…');
+    [hintButton, restartButton, solutionButton].forEach(button => { button.disabled = true; });
+    try {
+      const response = await fetch(API[mode]);
+      if (!response.ok) throw new Error(`Chess.com returned ${response.status}`);
+      puzzle = await response.json();
+      solution = parseSolution(puzzle.fen, puzzle.pgn);
+      if (!solution.length) throw new Error('No solution moves were available');
+      game = new Chess(puzzle.fen);
+      orientation = game.turn();
+      title.textContent = puzzle.title;
+      sideLabel.textContent = `${orientation === 'w' ? 'White' : 'Black'} to move`;
+      credit.href = puzzle.url;
+      credit.innerHTML = 'Puzzle provided by Chess.com — view original <span class="sr-only">(opens in a new tab)</span>';
+      [hintButton, restartButton, solutionButton].forEach(button => { button.disabled = false; });
+      restartPuzzle();
+    } catch (error) {
+      board.innerHTML = '';
+      board.setAttribute('aria-busy', 'false');
+      title.textContent = 'Puzzle unavailable';
+      setFeedback('The Chess.com puzzle could not be loaded right now. Please try again shortly.', 'error');
+    }
+  }
+
+  hintButton.addEventListener('click', () => {
+    if (!solution[solutionIndex] || locked) return;
+    hintLevel = Math.min(2, hintLevel + 1);
+    renderBoard();
+    setFeedback(hintLevel === 1 ? `Consider the piece on ${solution[solutionIndex].from}.` : `Look for a move from ${solution[solutionIndex].from} to ${solution[solutionIndex].to}.`);
+  });
+  restartButton.addEventListener('click', restartPuzzle);
+  solutionButton.addEventListener('click', showSolution);
+  dailyButton.addEventListener('click', () => loadPuzzle('daily'));
+  randomButton.addEventListener('click', () => loadPuzzle('random'));
+
+  renderProgress();
+  if (typeof Chess === 'undefined') setFeedback('The chessboard engine could not be loaded. Please refresh the page.', 'error');
+  else loadPuzzle('daily');
+}());
+


### PR DESCRIPTION
## What changed

- adds a Chess Puzzles item to the primary navbar
- adds an on-site interactive chessboard with original Unicode pieces and ChessJitsu board colors
- supports both Chess.com's current Daily Puzzle and random archived Daily Puzzle endpoints
- validates the visitor's moves against the supplied solution line and automatically plays opponent replies
- adds hints, restart, and animated solution controls
- orients the board to the side to move
- saves a Daily Puzzle streak and random-puzzle solve count locally on the visitor's device
- includes the visible Chess.com credit link required by the official API documentation
- includes keyboard-operable squares, accessible board labels, status announcements, and responsive layout

## Why

This gives ChessJitsu visitors a native tactics-training experience while using Chess.com's officially published puzzle data and respecting its attribution and visual-IP requirements.

## Validation

- JavaScript syntax check passed
- a live Chess.com Daily Puzzle FEN and PGN parsed successfully into an 11-move solution line
- Daily and Random API modes, interactive controls, attribution, local progress, and navbar route were verified