### PR TITLE
Fix puzzle board layout and navbar visibility

### DIFF
--- a/navbar.html
+++ b/navbar.html
@@ -1,6 +1,6 @@
 <!-- Navigation -->
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Primary navigation">
-  <div class="container">
+<nav class="navbar navbar-expand-xl navbar-dark bg-dark fixed-top" aria-label="Primary navigation">
+  <div class="container-fluid px-4 px-xl-5">
     <a class="navbar-brand" href="/">ChessJitsu.net</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
@@ -8,9 +8,9 @@
     <div class="collapse navbar-collapse" id="navbarResponsive">
       <ul class="navbar-nav ml-auto">
         <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="/puzzles/">Chess Puzzles</a></li>
         <li class="nav-item"><a class="nav-link" href="/meditation/">Chess Meditation</a></li>
         <li class="nav-item"><a class="nav-link" href="/meditation/builder.html">Chess Meditation Builder</a></li>
-        <li class="nav-item"><a class="nav-link" href="/puzzles/">Chess Puzzles</a></li>
         <li class="nav-item"><a class="nav-link" href="/contact">Contact</a></li>
       </ul>
     </div>

--- a/puzzles/puzzles.css
+++ b/puzzles/puzzles.css
@@ -1,14 +1,15 @@
 :root { --ink: #f7f5f2; --muted: #c8c3cc; --surface: #17151b; --card: #24212a; --accent: #a978b1; --accent-dark: #6b3972; --light-square: #ddd3c5; --dark-square: #72537a; }
-body { background: var(--surface); color: var(--ink); line-height: 1.65; padding-top: 56px; }
+body { background: var(--surface); color: var(--ink); line-height: 1.65; overflow-x: hidden; padding-top: 56px; }
 a { color: #dfb8e6; } a:hover { color: #fff; }
 .skip-link { background: #fff; color: #111; left: 1rem; padding: .75rem 1rem; position: fixed; top: -5rem; z-index: 2000; } .skip-link:focus { top: 1rem; }
 .puzzle-hero { background: linear-gradient(135deg, #17151b 15%, #56305d); padding: 4.5rem 0 3.5rem; text-align: center; }
 .puzzle-hero h1 { font-size: clamp(2.5rem, 7vw, 4.5rem); font-weight: 700; }
 .puzzle-hero > .container > p:last-child { color: var(--muted); font-size: 1.1rem; margin: 1rem auto 0; max-width: 40rem; }
 .eyebrow { color: #d8aee0; font-size: .82rem; font-weight: 700; letter-spacing: .12em; margin-bottom: .35rem; text-transform: uppercase; }
-.puzzle-layout { display: grid; gap: 2rem; grid-template-columns: minmax(0, 680px) minmax(250px, 1fr); padding-bottom: 4rem; padding-top: 4rem; }
+.puzzle-layout { display: grid; gap: 2rem; grid-template-columns: minmax(0, 580px) minmax(250px, 1fr); max-width: 1080px; padding-bottom: 4rem; padding-top: 4rem; }
 .puzzle-workspace, .puzzle-sidebar { background: var(--card); border: 1px solid #403a48; border-radius: .85rem; padding: clamp(1rem, 3vw, 2rem); }
-.puzzle-sidebar { align-self: start; position: sticky; top: 5rem; }
+.puzzle-workspace, .puzzle-sidebar { min-width: 0; }
+.puzzle-sidebar { align-self: start; overflow-wrap: anywhere; position: sticky; top: 5rem; }
 .mode-switcher, .puzzle-controls { display: flex; flex-wrap: wrap; gap: .75rem; }
 .mode-switcher { margin-bottom: 2rem; }
 .btn-puzzle { background: var(--accent-dark); border: 1px solid var(--accent); color: #fff; }
@@ -16,7 +17,7 @@ a { color: #dfb8e6; } a:hover { color: #fff; }
 .puzzle-heading { align-items: end; display: flex; gap: 1rem; justify-content: space-between; }
 .puzzle-heading h2 { font-size: clamp(1.45rem, 4vw, 2rem); }
 .side-to-move { color: var(--muted); white-space: nowrap; }
-.chessboard { aspect-ratio: 1; border: 4px solid #443749; border-radius: .4rem; display: grid; grid-template-columns: repeat(8, 1fr); margin: 1.25rem auto; max-width: 620px; overflow: hidden; width: 100%; }
+.chessboard { aspect-ratio: 1; border: 4px solid #443749; border-radius: .4rem; display: grid; grid-template-columns: repeat(8, 1fr); margin: 1.25rem auto; max-width: 520px; overflow: hidden; width: 100%; }
 .square { align-items: center; appearance: none; border: 0; border-radius: 0; color: #111; display: flex; font-family: "Segoe UI Symbol", "Arial Unicode MS", sans-serif; font-size: clamp(1.8rem, 7vw, 4.2rem); justify-content: center; line-height: 1; margin: 0; padding: 0; position: relative; }
 .square.light { background: var(--light-square); } .square.dark { background: var(--dark-square); }
 .square:hover { box-shadow: inset 0 0 0 4px rgba(255,255,255,.35); }
@@ -36,6 +37,6 @@ a { color: #dfb8e6; } a:hover { color: #fff; }
 .puzzle-sidebar h3 { font-size: 1.15rem; }
 .puzzle-sidebar li + li { margin-top: .55rem; }
 .site-footer { background: #343a40; color: #fff; padding: 2rem 0; text-align: center; }
-@media (max-width: 900px) { .puzzle-layout { grid-template-columns: 1fr; } .puzzle-sidebar { position: static; } }
+@media (max-width: 1050px) { .puzzle-layout { grid-template-columns: 1fr; max-width: 680px; } .puzzle-sidebar { position: static; } }
 @media (max-width: 520px) { .puzzle-heading { align-items: flex-start; flex-direction: column; } .square { font-size: clamp(1.8rem, 11vw, 3.4rem); } }
 


### PR DESCRIPTION
## What changed

- reduces and centers the puzzle board so the complete board and controls fit comfortably within the content area
- tightens the puzzle workspace to a 580px column with a 520px maximum board
- stacks the progress panel below the board at a wider 1050px breakpoint
- prevents horizontal page overflow and allows sidebar text to wrap
- makes the shared navbar use the full browser width
- changes the navbar collapse breakpoint so long labels move into the menu sooner
- places Chess Puzzles immediately after Home so it remains prominent

## Why

The first puzzle layout could extend beyond the visible page area, and the long meditation labels pushed the Chess Puzzles link offscreen. These responsive changes keep both the complete puzzle experience and its navigation entry visible.

## Validation

- live Chess.com Daily Puzzle still parsed successfully into an 11-move line
- full-width responsive navbar and prioritized puzzle link were verified
- 520px board cap and 1050px stacked-layout breakpoint were verified