### PR TITLE
Redesign puzzle board with classic pieces

### DIFF
--- a/puzzles/index.html
+++ b/puzzles/index.html
@@ -44,6 +44,7 @@
       </div>
 
       <p class="attribution"><a id="chess-credit" href="https://www.chess.com/puzzles" target="_blank" rel="noopener">Puzzle provided by Chess.com <span class="sr-only">(opens in a new tab)</span></a></p>
+      <small class="art-credit">Chess piece artwork by Cburnett via Wikimedia Commons, licensed under <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank" rel="noopener">CC BY-SA 3.0 <span class="sr-only">(opens in a new tab)</span></a>.</small>
     </section>
 
     <aside class="puzzle-sidebar" aria-labelledby="progress-heading">

--- a/puzzles/puzzles.css
+++ b/puzzles/puzzles.css
@@ -1,4 +1,4 @@
-:root { --ink: #f7f5f2; --muted: #c8c3cc; --surface: #17151b; --card: #24212a; --accent: #a978b1; --accent-dark: #6b3972; --light-square: #ddd3c5; --dark-square: #72537a; }
+:root { --ink: #f7f5f2; --muted: #c8c3cc; --surface: #17151b; --card: #24212a; --accent: #a978b1; --accent-dark: #6b3972; --light-square: #eeeed2; --dark-square: #537fa4; }
 body { background: var(--surface); color: var(--ink); line-height: 1.65; overflow-x: hidden; padding-top: 56px; }
 a { color: #dfb8e6; } a:hover { color: #fff; }
 .skip-link { background: #fff; color: #111; left: 1rem; padding: .75rem 1rem; position: fixed; top: -5rem; z-index: 2000; } .skip-link:focus { top: 1rem; }
@@ -6,7 +6,7 @@ a { color: #dfb8e6; } a:hover { color: #fff; }
 .puzzle-hero h1 { font-size: clamp(2.5rem, 7vw, 4.5rem); font-weight: 700; }
 .puzzle-hero > .container > p:last-child { color: var(--muted); font-size: 1.1rem; margin: 1rem auto 0; max-width: 40rem; }
 .eyebrow { color: #d8aee0; font-size: .82rem; font-weight: 700; letter-spacing: .12em; margin-bottom: .35rem; text-transform: uppercase; }
-.puzzle-layout { display: grid; gap: 2rem; grid-template-columns: minmax(0, 580px) minmax(250px, 1fr); max-width: 1080px; padding-bottom: 4rem; padding-top: 4rem; }
+.puzzle-layout { display: grid; gap: 2rem; grid-template-columns: minmax(0, 540px) minmax(250px, 320px); justify-content: center; max-width: 940px; padding-bottom: 4rem; padding-top: 4rem; }
 .puzzle-workspace, .puzzle-sidebar { background: var(--card); border: 1px solid #403a48; border-radius: .85rem; padding: clamp(1rem, 3vw, 2rem); }
 .puzzle-workspace, .puzzle-sidebar { min-width: 0; }
 .puzzle-sidebar { align-self: start; overflow-wrap: anywhere; position: sticky; top: 5rem; }
@@ -17,20 +17,25 @@ a { color: #dfb8e6; } a:hover { color: #fff; }
 .puzzle-heading { align-items: end; display: flex; gap: 1rem; justify-content: space-between; }
 .puzzle-heading h2 { font-size: clamp(1.45rem, 4vw, 2rem); }
 .side-to-move { color: var(--muted); white-space: nowrap; }
-.chessboard { aspect-ratio: 1; border: 4px solid #443749; border-radius: .4rem; display: grid; grid-template-columns: repeat(8, 1fr); margin: 1.25rem auto; max-width: 520px; overflow: hidden; width: 100%; }
-.square { align-items: center; appearance: none; border: 0; border-radius: 0; color: #111; display: flex; font-family: "Segoe UI Symbol", "Arial Unicode MS", sans-serif; font-size: clamp(1.8rem, 7vw, 4.2rem); justify-content: center; line-height: 1; margin: 0; padding: 0; position: relative; }
+.chessboard { aspect-ratio: 1; border: 4px solid #343941; border-radius: .35rem; box-shadow: 0 .75rem 2rem rgba(0,0,0,.28); display: grid; grid-template-columns: repeat(8, 1fr); margin: 1.25rem auto; max-width: 500px; overflow: hidden; width: min(100%, calc(100vh - 300px)); }
+.square { align-items: center; appearance: none; border: 0; border-radius: 0; color: #111; display: flex; justify-content: center; line-height: 1; margin: 0; min-width: 0; padding: 0; position: relative; }
 .square.light { background: var(--light-square); } .square.dark { background: var(--dark-square); }
 .square:hover { box-shadow: inset 0 0 0 4px rgba(255,255,255,.35); }
 .square:focus-visible { outline: 4px solid #ffd36a; outline-offset: -4px; z-index: 2; }
 .square.selected { box-shadow: inset 0 0 0 5px #ffd36a; }
 .square.hint-from { box-shadow: inset 0 0 0 5px #85d7ff; }
 .square.hint-to::after { background: rgba(40,170,95,.65); border-radius: 50%; content: ""; height: 28%; position: absolute; width: 28%; }
-.piece.black-piece { color: #161219; text-shadow: 0 1px 0 rgba(255,255,255,.35); }
-.piece.white-piece { color: #fff; text-shadow: 0 1px 2px #000, 0 0 1px #000; }
+.piece-image { height: 88%; object-fit: contain; pointer-events: none; position: relative; user-select: none; width: 88%; z-index: 1; }
+.coordinate { font-size: clamp(.55rem, 1.5vw, .72rem); font-weight: 700; line-height: 1; pointer-events: none; position: absolute; z-index: 2; }
+.rank-coordinate { left: .22rem; top: .22rem; }
+.file-coordinate { bottom: .18rem; right: .22rem; }
+.square.light .coordinate { color: #537fa4; }
+.square.dark .coordinate { color: #eeeed2; }
 .puzzle-feedback { background: #1b1920; border-left: 3px solid var(--accent); border-radius: 0 .4rem .4rem 0; min-height: 3.3rem; padding: .8rem 1rem; }
 .puzzle-feedback.success { border-left-color: #5fd58a; color: #bdf5cf; }
 .puzzle-feedback.error { border-left-color: #ff8c8c; color: #ffd0d0; }
-.attribution { margin: 1.5rem 0 0; text-align: center; }
+.attribution { margin: 1.5rem 0 .2rem; text-align: center; }
+.art-credit { color: var(--muted); display: block; font-size: .74rem; text-align: center; }
 .stat-grid { display: grid; gap: .75rem; grid-template-columns: 1fr 1fr; margin: 1.5rem 0 2rem; }
 .stat-grid div { background: #1b1920; border-radius: .65rem; padding: 1rem; text-align: center; }
 .stat-grid strong { display: block; font-size: 2rem; } .stat-grid span, .puzzle-sidebar > p { color: var(--muted); }
@@ -38,5 +43,5 @@ a { color: #dfb8e6; } a:hover { color: #fff; }
 .puzzle-sidebar li + li { margin-top: .55rem; }
 .site-footer { background: #343a40; color: #fff; padding: 2rem 0; text-align: center; }
 @media (max-width: 1050px) { .puzzle-layout { grid-template-columns: 1fr; max-width: 680px; } .puzzle-sidebar { position: static; } }
-@media (max-width: 520px) { .puzzle-heading { align-items: flex-start; flex-direction: column; } .square { font-size: clamp(1.8rem, 11vw, 3.4rem); } }
+@media (max-width: 520px) { .puzzle-heading { align-items: flex-start; flex-direction: column; } .chessboard { width: 100%; } }
 

--- a/puzzles/puzzles.js
+++ b/puzzles/puzzles.js
@@ -2,7 +2,8 @@
   'use strict';
 
   const API = { daily: 'https://api.chess.com/pub/puzzle', random: 'https://api.chess.com/pub/puzzle/random' };
-  const pieces = { wp: '♙', wn: '♘', wb: '♗', wr: '♖', wq: '♕', wk: '♔', bp: '♟', bn: '♞', bb: '♝', br: '♜', bq: '♛', bk: '♚' };
+  const pieceImageBase = 'https://chessboardjs.com/img/chesspieces/wikipedia/';
+  const pieces = { wp: 'wP', wn: 'wN', wb: 'wB', wr: 'wR', wq: 'wQ', wk: 'wK', bp: 'bP', bn: 'bN', bb: 'bB', br: 'bR', bq: 'bQ', bk: 'bK' };
   const pieceNames = { p: 'pawn', n: 'knight', b: 'bishop', r: 'rook', q: 'queen', k: 'king' };
   const board = document.querySelector('#chessboard');
   const title = document.querySelector('#puzzle-title');
@@ -58,7 +59,7 @@
 
   function renderBoard() {
     board.innerHTML = '';
-    boardSquares().forEach(squareName => {
+    boardSquares().forEach((squareName, index) => {
       const square = document.createElement('button');
       const fileNumber = squareName.charCodeAt(0) - 96;
       const rankNumber = Number(squareName[1]);
@@ -72,11 +73,25 @@
       if (hintLevel >= 1 && solution[solutionIndex] && squareName === solution[solutionIndex].from) square.classList.add('hint-from');
       if (hintLevel >= 2 && solution[solutionIndex] && squareName === solution[solutionIndex].to) square.classList.add('hint-to');
       if (piece) {
-        const span = document.createElement('span');
-        span.className = `piece ${piece.color === 'w' ? 'white-piece' : 'black-piece'}`;
-        span.setAttribute('aria-hidden', 'true');
-        span.textContent = pieces[`${piece.color}${piece.type}`];
-        square.appendChild(span);
+        const image = document.createElement('img');
+        image.className = 'piece-image';
+        image.src = `${pieceImageBase}${pieces[`${piece.color}${piece.type}`]}.png`;
+        image.alt = '';
+        image.draggable = false;
+        image.setAttribute('aria-hidden', 'true');
+        square.appendChild(image);
+      }
+      if (index % 8 === 0) {
+        const rank = document.createElement('span');
+        rank.className = 'coordinate rank-coordinate';
+        rank.textContent = squareName[1];
+        square.appendChild(rank);
+      }
+      if (index >= 56) {
+        const file = document.createElement('span');
+        file.className = 'coordinate file-coordinate';
+        file.textContent = squareName[0];
+        square.appendChild(file);
       }
       square.addEventListener('click', () => chooseSquare(squareName));
       board.appendChild(square);


### PR DESCRIPTION
## What changed

- replaces the oversized Unicode chess symbols with classic Staunton-style image pieces
- changes the board to a calmer blue-and-ivory color palette inspired by the supplied reference
- adds file and rank coordinates that follow the player’s board orientation
- caps the board at 500px and also sizes it against the viewport height so the complete puzzle stays visible
- narrows and centers the overall puzzle layout for a more balanced presentation
- preserves keyboard labels, hints, move validation, Daily Puzzle, Random Puzzle, and progress tracking
- adds the required CC BY-SA artwork credit while keeping Chess.com credited as the puzzle-data source

## Validation

- JavaScript syntax check passed
- live Chess.com Daily Puzzle parsed completely into an 11-move solution
- classic piece image source returned successfully
- responsive 500px board cap, viewport-aware sizing, coordinates, credits, and navbar link were verified