### PR TITLE
Improve puzzle board fit

### DIFF
--- a/puzzles/puzzles.css
+++ b/puzzles/puzzles.css
@@ -6,7 +6,7 @@ a { color: #dfb8e6; } a:hover { color: #fff; }
 .puzzle-hero h1 { font-size: clamp(2.5rem, 7vw, 4.5rem); font-weight: 700; }
 .puzzle-hero > .container > p:last-child { color: var(--muted); font-size: 1.1rem; margin: 1rem auto 0; max-width: 40rem; }
 .eyebrow { color: #d8aee0; font-size: .82rem; font-weight: 700; letter-spacing: .12em; margin-bottom: .35rem; text-transform: uppercase; }
-.puzzle-layout { display: grid; gap: 2rem; grid-template-columns: minmax(0, 540px) minmax(250px, 320px); justify-content: center; max-width: 940px; padding-bottom: 4rem; padding-top: 4rem; }
+.puzzle-layout { display: grid; gap: 1.5rem; grid-template-columns: minmax(0, 470px) minmax(250px, 300px); justify-content: center; max-width: 820px; padding-bottom: 4rem; padding-top: 4rem; }
 .puzzle-workspace, .puzzle-sidebar { background: var(--card); border: 1px solid #403a48; border-radius: .85rem; padding: clamp(1rem, 3vw, 2rem); }
 .puzzle-workspace, .puzzle-sidebar { min-width: 0; }
 .puzzle-sidebar { align-self: start; overflow-wrap: anywhere; position: sticky; top: 5rem; }
@@ -17,7 +17,7 @@ a { color: #dfb8e6; } a:hover { color: #fff; }
 .puzzle-heading { align-items: end; display: flex; gap: 1rem; justify-content: space-between; }
 .puzzle-heading h2 { font-size: clamp(1.45rem, 4vw, 2rem); }
 .side-to-move { color: var(--muted); white-space: nowrap; }
-.chessboard { aspect-ratio: 1; border: 4px solid #343941; border-radius: .35rem; box-shadow: 0 .75rem 2rem rgba(0,0,0,.28); display: grid; grid-template-columns: repeat(8, 1fr); margin: 1.25rem auto; max-width: 500px; overflow: hidden; width: min(100%, calc(100vh - 300px)); }
+.chessboard { aspect-ratio: 1; border: 4px solid #343941; border-radius: .35rem; box-shadow: 0 .75rem 2rem rgba(0,0,0,.28); display: grid; grid-template-columns: repeat(8, 1fr); margin: 1.25rem auto; max-width: 420px; overflow: hidden; width: min(100%, calc(100vh - 390px)); }
 .square { align-items: center; appearance: none; border: 0; border-radius: 0; color: #111; display: flex; justify-content: center; line-height: 1; margin: 0; min-width: 0; padding: 0; position: relative; }
 .square.light { background: var(--light-square); } .square.dark { background: var(--dark-square); }
 .square:hover { box-shadow: inset 0 0 0 4px rgba(255,255,255,.35); }
@@ -42,6 +42,7 @@ a { color: #dfb8e6; } a:hover { color: #fff; }
 .puzzle-sidebar h3 { font-size: 1.15rem; }
 .puzzle-sidebar li + li { margin-top: .55rem; }
 .site-footer { background: #343a40; color: #fff; padding: 2rem 0; text-align: center; }
-@media (max-width: 1050px) { .puzzle-layout { grid-template-columns: 1fr; max-width: 680px; } .puzzle-sidebar { position: static; } }
+@media (max-width: 1050px) { .puzzle-layout { grid-template-columns: 1fr; max-width: 540px; padding-top: 3rem; } .puzzle-sidebar { position: static; } }
+@media (max-height: 800px) and (min-width: 521px) { .chessboard { max-width: 380px; } .puzzle-layout { padding-top: 2.5rem; } .mode-switcher { margin-bottom: 1.25rem; } }
 @media (max-width: 520px) { .puzzle-heading { align-items: flex-start; flex-direction: column; } .chessboard { width: 100%; } }
 


### PR DESCRIPTION
## What changed

- reduces the puzzle board maximum size from 500px to 420px
- reduces it again to 380px on shorter laptop screens
- narrows and centers the puzzle workspace and progress column
- tightens the layout spacing while retaining comfortable room around the board
- preserves the classic pieces, blue-and-ivory styling, coordinates, puzzle controls, and responsive stacking

## Why

The redesigned board was still visually dominant and could push the feedback and controls below the visible area. The new dimensions keep the complete puzzle experience better balanced within common laptop viewports.

## Validation

- live Chess.com Daily Puzzle parsed completely into an 11-move solution
- 420px standard cap and 380px short-screen cap verified
- classic piece images, coordinates, credits, and navbar link verified