### PR TITLE
Replace remaining gold accents with purple

### DIFF
--- a/chessjitsu/index.html
+++ b/chessjitsu/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ChessJitsu | ChessJitsu.net</title>
   <meta name="description" content="Discover the ChessJitsu concept, watch the first exhibition, and read the original rules.">
-  <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet"><link href="/css/home.css" rel="stylesheet">
+  <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet"><link href="/css/home.css?v=2" rel="stylesheet">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"><script src="/vendor/jquery/jquery.min.js"></script>
 </head>
 <body>

--- a/css/home.css
+++ b/css/home.css
@@ -1,4 +1,4 @@
-:root { --ink:#121116; --paper:#f4f0e8; --purple:#8d4e99; --purple-light:#c58bd0; --purple-deep:#251a2b; --gold:#a968b4; --muted:#6f6873; }
+:root { --ink:#121116; --paper:#f4f0e8; --purple:#8d4e99; --purple-light:#c58bd0; --purple-deep:#251a2b; --accent:#a968b4; --muted:#6f6873; }
 * { box-sizing:border-box; }
 html { scroll-behavior:smooth; }
 body { background:var(--paper); color:var(--ink); font-family:Arial,Helvetica,sans-serif; line-height:1.65; margin:0; padding-top:56px; }
@@ -8,7 +8,7 @@ a { color:inherit; }
 .home-hero { align-items:center; background:#111317 url('/ChessJitsuCoverPhotoUltimate.png') center/cover no-repeat; color:#fff; display:flex; min-height:min(780px,calc(100vh - 56px)); overflow:hidden; position:relative; }
 .hero-overlay { background:linear-gradient(90deg,rgba(12,12,15,.96) 0%,rgba(23,16,26,.86) 50%,rgba(16,12,19,.42) 100%); inset:0; position:absolute; }
 .hero-content { padding-bottom:6rem; padding-top:6rem; position:relative; z-index:1; }
-.eyebrow { color:#e3b96f; font-size:.78rem; font-weight:700; letter-spacing:.2em; margin:0 0 1rem; text-transform:uppercase; }
+.eyebrow { color:var(--purple-light); font-size:.78rem; font-weight:700; letter-spacing:.2em; margin:0 0 1rem; text-transform:uppercase; }
 .eyebrow.dark { color:var(--purple); }
 .home-hero h1 { font-family:Georgia,'Times New Roman',serif; font-size:clamp(3rem,6.5vw,6rem); font-weight:700; letter-spacing:-.045em; line-height:1.02; margin:0; max-width:1050px; }
 .home-hero h1 span { color:var(--purple-light); }
@@ -30,14 +30,14 @@ a { color:inherit; }
 .pathways h2 { margin-bottom:3rem; }
 .pathway-grid { display:grid; gap:1px; grid-template-columns:repeat(3,1fr); }
 .pathway-card { background:#312537; border-top:3px solid transparent; min-height:360px; padding:2rem; position:relative; }
-.pathway-card.featured { border-top-color:var(--gold); }
+.pathway-card.featured { border-top-color:var(--accent); }
 .card-number { color:#9e91a3; font-size:.75rem; letter-spacing:.15em; }
-.card-icon { color:#d6ac63; font-size:3.2rem; line-height:1; margin:2.5rem 0 1.4rem; }
+.card-icon { color:var(--purple-light); font-size:3.2rem; line-height:1; margin:2.5rem 0 1.4rem; }
 .pathway-card h3 { font-family:Georgia,serif; font-size:1.7rem; }
 .pathway-card p { color:#c9c0cd; }
-.pathway-card a { bottom:2rem; color:#e6bd75; font-weight:700; position:absolute; text-decoration:none; }
+.pathway-card a { bottom:2rem; color:var(--purple-light); font-weight:700; position:absolute; text-decoration:none; }
 .pathway-card a:hover,.pathway-card a:focus { color:#fff; }
-.manifesto { background:var(--gold); color:#211a24; padding:6rem 0; text-align:center; }
+.manifesto { background:var(--accent); color:#211a24; padding:6rem 0; text-align:center; }
 .manifesto-inner { max-width:900px; }
 .manifesto-piece { font-size:3rem; }
 .manifesto blockquote { font-family:Georgia,serif; font-size:clamp(2rem,5vw,4rem); font-weight:700; letter-spacing:-.03em; line-height:1.15; margin:1rem 0; }

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>ChessJitsu.net | Train the Mind. Test the Body.</title>
   <meta name="description" content="Explore ChessJitsu, chess meditation, and mindful training designed to strengthen focus, resilience, and creativity.">
   <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-  <link href="/css/home.css" rel="stylesheet">
+  <link href="/css/home.css?v=2" rel="stylesheet">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <script src="/vendor/jquery/jquery.min.js"></script>
 </head>


### PR DESCRIPTION
## What changed

- replaces every remaining legacy gold color in the shared Home/ChessJitsu stylesheet with the purple palette
- updates eyebrow text, card icons, links, featured borders, and accent backgrounds
- renames the old `--gold` design token to `--accent`
- versions the stylesheet URL on Home and ChessJitsu so browsers immediately fetch the new colors instead of displaying a cached gold version

## Validation

- confirmed the stylesheet contains none of the legacy gold values
- confirmed both pages use the new versioned stylesheet URL
- confirmed Home and ChessJitsu navigation and responsive styling remain intact