### PR TITLE
Restyle ChessJitsu hub to match meditation

### DIFF
--- a/chessjitsu/hub.css
+++ b/chessjitsu/hub.css
@@ -1,0 +1,36 @@
+:root {
+  --ink: #f7f5f2;
+  --muted: #c8c3cc;
+  --surface: #17151b;
+  --card: #24212a;
+  --accent: #a978b1;
+  --accent-dark: #6b3972;
+}
+html { scroll-behavior: smooth; }
+body { background: var(--surface); color: var(--ink); font-family: Arial, sans-serif; line-height: 1.65; padding-top: 56px; }
+a { color: #dfb8e6; }
+a:hover { color: #fff; }
+.skip-link { background: #fff; color: #111; left: 1rem; padding: .75rem 1rem; position: fixed; top: -5rem; z-index: 2000; }
+.skip-link:focus { top: 1rem; }
+.concept-hero { background: linear-gradient(135deg, rgba(20,18,24,.92), rgba(107,57,114,.84)), url('/ChessJitsuCoverPhotoUltimate.png') center/cover; padding: 6rem 0 5rem; text-align: center; }
+.concept-hero h1 { font-size: clamp(2.8rem, 8vw, 5rem); font-weight: 700; }
+.concept-hero > .container > p:last-child { color: var(--muted); font-size: 1.15rem; margin: 1rem auto 0; max-width: 48rem; }
+.eyebrow { color: #d8aee0; font-size: .85rem; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
+.concept-notes { background: var(--card); border-radius: .75rem; margin-top: 2rem; padding: 1.5rem; }
+.concept-notes h2 { font-size: clamp(1.6rem, 4vw, 2rem); }
+.concept-notes > p:last-child { color: var(--muted); margin-bottom: 0; }
+.resource-grid { display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); padding: 4rem 0; }
+.resource-card { background: var(--card); border: 1px solid #403a48; border-radius: .75rem; display: flex; flex-direction: column; overflow: hidden; }
+.resource-card img, .article-art { aspect-ratio: 16/9; width: 100%; }
+.resource-card img { object-fit: cover; }
+.article-art { align-items: center; background: linear-gradient(135deg, #17151b, #6b3972); display: flex; flex-direction: column; justify-content: center; text-align: center; }
+.article-art span { color: #d8aee0; font-size: clamp(1.4rem, 4vw, 2.2rem); font-weight: 700; letter-spacing: .04em; }
+.article-art strong { color: #fff; font-family: Georgia, serif; font-size: clamp(2.2rem, 6vw, 4rem); line-height: 1; }
+.resource-card-body { display: flex; flex: 1; flex-direction: column; padding: 1.5rem; }
+.resource-card-body h2 { font-size: 1.55rem; }
+.resource-card-body > p:not(.eyebrow) { color: var(--muted); }
+.btn-resource { align-self: flex-start; background: var(--accent-dark); border: 1px solid var(--accent); color: #fff; margin-top: auto; }
+.btn-resource:hover, .btn-resource:focus { background: var(--accent); border-color: #fff; color: #111; }
+.site-footer { background: #343a40; color: #fff; padding: 2rem 0; text-align: center; }
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+

--- a/chessjitsu/index.html
+++ b/chessjitsu/index.html
@@ -1,25 +1,67 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>ChessJitsu | ChessJitsu.net</title>
-  <meta name="description" content="Discover the ChessJitsu concept, watch the first exhibition, and read the original rules.">
-  <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet"><link href="/css/home.css?v=2" rel="stylesheet">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"><script src="/vendor/jquery/jquery.min.js"></script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ChessJitsu Sport | ChessJitsu.net</title>
+  <meta name="description" content="Discover the ChessJitsu hybrid sport, watch the first exhibition, and read the original rules.">
+  <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/chessjitsu/hub.css?v=1" rel="stylesheet">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <script src="/vendor/jquery/jquery.min.js"></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a><div id="navbar_container"></div>
-  <header class="concept-hero"><div class="container"><p class="eyebrow">The original concept</p><h1>ChessJitsu</h1><p>Chess strategy and Brazilian Jiu-Jitsu meet in an experiment about composure, adaptation, and problem-solving.</p></div></header>
-  <main id="main-content" class="concept-main" tabindex="-1">
-    <section class="container concept-intro"><p class="eyebrow dark">Learn the game</p><h2>Start with the story. See it in motion.</h2><p>Explore the original explanation, the concept video, and the first exhibition pilot match—all hosted here on ChessJitsu.net.</p></section>
-    <section class="container concept-grid" aria-label="ChessJitsu resources">
-      <article class="concept-card"><a href="/chessjitsu/exhibition-match.html"><img src="/images/ChessJitsuImportant.jpg" alt="ChessJitsu exhibition match participants"></a><div><p class="eyebrow dark">Watch</p><h2>Exhibition Pilot Match</h2><p>See ChessJitsu demonstrated in an open-mat Brazilian Jiu-Jitsu gym setting.</p><a class="button button-dark" href="/chessjitsu/exhibition-match.html">Watch the match</a></div></article>
-      <article class="concept-card reverse"><a href="/chessjitsu/concept-video.html"><img src="/images/ChessJitsuWebsite.jpg" alt="Two ChessJitsu players seated behind chessboards"></a><div><p class="eyebrow dark">Understand</p><h2>Concept Video</h2><p>Hear the idea explained and discover how two strategic disciplines inspired one experiment.</p><a class="button button-dark" href="/chessjitsu/concept-video.html">Watch the concept</a></div></article>
-      <article class="concept-card"><a href="/chessjitsu/rules.html"><img class="contain-image" src="/ChessJitsuonMedium.png" alt="ChessJitsu on Medium"></a><div><p class="eyebrow dark">Read</p><h2>The Original Rules</h2><p>Read the founding article and learn the structure behind this novelty sport.</p><a class="button button-dark" href="/chessjitsu/rules.html">Read the rules</a></div></article>
+  <a class="skip-link" href="#main-content">Skip to ChessJitsu resources</a>
+  <div id="navbar_container"></div>
+  <header class="concept-hero">
+    <div class="container">
+      <p class="eyebrow">A novelty hybrid sport</p>
+      <h1>ChessJitsu</h1>
+      <p>ChessBoxing is a cool idea- but as a chess player you want to avoid brain damage, enter ChessJitsu</p>
+    </div>
+  </header>
+  <main id="main-content" class="container" tabindex="-1">
+    <section class="concept-notes" aria-labelledby="learn-heading">
+      <p class="eyebrow">Learn the sport</p>
+      <h2 id="learn-heading">Start with the story. See it in motion.</h2>
+      <p>Explore the original explanation, the concept video, and the first exhibition pilot match—all hosted here on ChessJitsu.net.</p>
+    </section>
+    <section class="resource-grid" aria-label="ChessJitsu resources">
+      <article class="resource-card">
+        <img src="/images/ChessJitsuImportant.jpg" alt="ChessJitsu exhibition match participants">
+        <div class="resource-card-body">
+          <p class="eyebrow">Watch</p>
+          <h2>Exhibition Pilot Match</h2>
+          <p>See ChessJitsu demonstrated in an open-mat Brazilian Jiu-Jitsu gym setting.</p>
+          <a class="btn btn-resource" href="/chessjitsu/exhibition-match.html">Watch the match</a>
+        </div>
+      </article>
+      <article class="resource-card">
+        <img src="/images/ChessJitsuWebsite.jpg" alt="Two ChessJitsu players seated behind chessboards">
+        <div class="resource-card-body">
+          <p class="eyebrow">Understand</p>
+          <h2>Concept Video</h2>
+          <p>Hear the idea explained and discover how two strategic disciplines inspired one experiment.</p>
+          <a class="btn btn-resource" href="/chessjitsu/concept-video.html">Watch the concept</a>
+        </div>
+      </article>
+      <article class="resource-card">
+        <div class="article-art" role="img" aria-label="ChessJitsu Article">
+          <span>ChessJitsu</span>
+          <strong>Article</strong>
+        </div>
+        <div class="resource-card-body">
+          <p class="eyebrow">Read</p>
+          <h2>The Original Rules</h2>
+          <p>Read the founding article and learn the structure behind this novelty sport.</p>
+          <a class="btn btn-resource" href="/chessjitsu/rules.html">Read the article</a>
+        </div>
+      </article>
     </section>
   </main>
-  <footer class="site-footer"><div class="container"><p>Copyright &copy; ChessJitsu.net 2026</p></div></footer>
-  <script>$(function () { $('#navbar_container').load('/navbar.html'); });</script><script src="/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <footer class="site-footer"><div class="container"><p class="mb-0">Copyright &copy; ChessJitsu.net 2026</p></div></footer>
+  <script>$(function () { $('#navbar_container').load('/navbar.html'); });</script>
+  <script src="/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## What changed

- changes “The original concept” to “A novelty hybrid sport”
- replaces the hero description with the requested ChessBoxing introduction
- restyles the page to match Chess Meditation’s dark purple hero, highlighted introduction panel, and responsive three-card grid
- replaces the old Medium graphic with a purpose-built text cover reading “ChessJitsu Article”
- keeps the exhibition match, concept video, and rules article hosted on ChessJitsu.net
- updates button styling, focus treatment, mobile layout, and reduced-motion support

## Validation

- exact requested hero wording verified
- old `ChessJitsuonMedium.png` reference verified absent
- all three internal resource links verified
- dedicated versioned stylesheet and responsive layout verified