### PR TITLE
Simplify commute meditation text

### DIFF
--- a/meditation/index.html
+++ b/meditation/index.html
@@ -39,7 +39,7 @@
       </article>
       <article class="practice-card">
         <img src="https://img.youtube.com/vi/svXwrWxJksc/hqdefault.jpg" alt="Thumbnail for Meditation Practice 3" loading="lazy">
-        <div class="practice-card-body"><h2>Chess Mental Training | Commute Edition</h2><p>This audio session is designed for a walk, a bike ride, a commute, or any other time when you want to reinforce your chess thinking away from the board.</p><a class="btn btn-primary" href="/meditation/practice-three.html">Begin practice</a></div>
+        <div class="practice-card-body"><h2>Mental Training | Commute Edition</h2><p>This audio session is designed for a walk, a bike ride, or a commute.</p><a class="btn btn-primary" href="/meditation/practice-three.html">Begin practice</a></div>
       </article>
     </div>
   </main>


### PR DESCRIPTION
## What changed

- changes the third card title to “Mental Training | Commute Edition”
- shortens its description to “This audio session is designed for a walk, a bike ride, or a commute.”

## Scope

Only these two text strings changed. Everything else remains untouched.

## Validation

- new wording verified
- superseded wording verified absent