### PR TITLE
Update ChessJitsu social preview title

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>ChessJitsu.net | Train the Mind. Test the Body.</title>
+  <title>ChessJitsu.net | Chess + Brazilian Jiu-Jitsu</title>
   <meta name="description" content="Explore ChessJitsu, chess meditation, and mindful training designed to strengthen focus, resilience, and creativity.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://www.chessjitsu.net/">
+  <meta property="og:title" content="ChessJitsu.net | Chess + Brazilian Jiu-Jitsu">
+  <meta property="og:description" content="Explore ChessJitsu, chess meditation, and mindful training designed to strengthen focus, resilience, and creativity.">
+  <meta property="og:image" content="https://www.chessjitsu.net/ChessJitsuCoverPhotoUltimate.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="ChessJitsu.net | Chess + Brazilian Jiu-Jitsu">
+  <meta name="twitter:description" content="Explore ChessJitsu, chess meditation, and mindful training designed to strengthen focus, resilience, and creativity.">
+  <meta name="twitter:image" content="https://www.chessjitsu.net/ChessJitsuCoverPhotoUltimate.png">
   <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="/css/home.css?v=2" rel="stylesheet">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">


### PR DESCRIPTION
## What changed

- changes the homepage browser title to “ChessJitsu.net | Chess + Brazilian Jiu-Jitsu”
- adds explicit Open Graph metadata for LinkedIn and other social platforms
- adds equivalent social-card metadata for platforms that read Twitter card tags
- uses the existing ChessJitsu cover artwork as the preview image

## Scope

No visible homepage content, styling, navigation, or behavior changed.

## Validation

- browser title verified
- LinkedIn/Open Graph title, description, URL, and image verified
- secondary social-card metadata verified