### PR TITLE
Remove analytics and ads; add ChessJitsu app privacy pages

### DIFF
--- a/apps/boxinggame.html
+++ b/apps/boxinggame.html
@@ -1,14 +1,7 @@
 <DOCTYPE html>
 <html>
 <body>
-<head><!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-W5D9JW8QXC"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
+<head>
   <title>Boxing Game</title>
     <meta name=”keywords” content="Boxing, UFC, MMA, BJJ, Brazilian Jiu-Jitsu, App">
   <meta name=”description” content="Boxing Game”>
@@ -19,7 +12,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-<script data-ad-client="ca-pub-5378984455419416" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>  <!-- Bootstrap core CSS -->
+<!-- Bootstrap core CSS -->
   <link href="https://paradoxbjj.com/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
   <!-- Custom styles for this template -->

--- a/apps/brucelee/brucelee.html
+++ b/apps/brucelee/brucelee.html
@@ -2,12 +2,6 @@
 <html>
 <body>
 <head>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
   <title>Bruce Lee Quote Machine</title>
     <meta name=”keywords” content="Bruce Lee, Mike Tyson, Tony Ferguson, UFC, MMA, BJJ, Brazilian Jiu-Jitsu, App">
   <meta name=”description” content="Bruce Lee quotes”>
@@ -18,8 +12,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1304055128700343"
-     crossorigin="anonymous"></script><!-- Bootstrap core CSS -->
+<!-- Bootstrap core CSS -->
   <link href="https://chessjitsu.net/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
   <!-- Custom styles for this template -->

--- a/apps/index.html
+++ b/apps/index.html
@@ -2,12 +2,6 @@
 <html>
 <body>
 <head>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
   <title>Quote Pages</title>
     <meta name=”keywords” content="Games and Apps, Mike Tyson, Tony Ferguson, UFC, MMA, BJJ, Brazilian Jiu-Jitsu, App">
   <meta name=”description” content="Games and Apps directory”>
@@ -18,8 +12,6 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1304055128700343"
-     crossorigin="anonymous"></script>
 <!-- Bootstrap core CSS -->
   <link href="https://chessjitsu.net/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 

--- a/apps/miketyson.html
+++ b/apps/miketyson.html
@@ -1,14 +1,7 @@
 <DOCTYPE html>
 <html>
 <body>
-<head><!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-W5D9JW8QXC"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
+<head>
   <title>Mike Tyson App</title>
     <meta name=”keywords” content="Mike Tyson, Tony Ferguson, UFC, MMA, BJJ, Brazilian Jiu-Jitsu, App">
   <meta name=”description” content="Mike Tyson says the darnest things”>
@@ -19,8 +12,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5378984455419416"
-     crossorigin="anonymous"></script>  <!-- Bootstrap core CSS -->
+<!-- Bootstrap core CSS -->
   <link href="https://chessjitsu.net/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
   <!-- Custom styles for this template -->

--- a/apps/titoortiz/tito.html
+++ b/apps/titoortiz/tito.html
@@ -1,13 +1,7 @@
 <DOCTYPE html>
 <html>
 <body>
-<head><!-- Global site tag (gtag.js) - Google Analytics -->
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
+<head>
   <title>Tito Ortiz quotes</title>
     <meta name=”keywords” content="Tito Ortiz, Mike Tyson, Tony Ferguson, UFC, MMA, BJJ, Brazilian Jiu-Jitsu, App">
   <meta name=”description” content="Tito Ortiz says the darnest things”>
@@ -18,8 +12,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1304055128700343"
-     crossorigin="anonymous"></script>  <!-- Bootstrap core CSS -->
+<!-- Bootstrap core CSS -->
   <link href="https://chessjitsu.net/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
   <!-- Custom styles for this template -->

--- a/apps/tonyFerguson.html
+++ b/apps/tonyFerguson.html
@@ -2,12 +2,6 @@
 <html>
 <body>
 <head>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
   <title>Tony Ferguson App</title>
     <meta name=”keywords” content="Tony Ferguson, UFC, MMA, BJJ, Brazilian Jiu-Jitsu, App">
   <meta name=”description” content="The Tony Ferguson App! Tony Ferguson is the type of guy that...”>
@@ -18,8 +12,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1304055128700343"
-     crossorigin="anonymous"></script> <link href="https://chessjitsu.net/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://chessjitsu.net/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
   <!-- Custom styles for this template -->
   <link href="css/heroic-features.css" rel="stylesheet">

--- a/apps/tyson/miketyson.html
+++ b/apps/tyson/miketyson.html
@@ -2,12 +2,6 @@
 <html>
 <body>
 <head>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
   <title>Mike Tyson App</title>
     <meta name=”keywords” content="Mike Tyson, Tony Ferguson, UFC, MMA, BJJ, Brazilian Jiu-Jitsu, App">
   <meta name=”description” content="Mike Tyson says the darnest things”>
@@ -18,8 +12,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1304055128700343"
-     crossorigin="anonymous"></script><!-- Bootstrap core CSS -->
+<!-- Bootstrap core CSS -->
   <link href="https://chessjitsu.net/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
   <!-- Custom styles for this template -->

--- a/articles/cauliflower.html
+++ b/articles/cauliflower.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1304055128700343"
-     crossorigin="anonymous"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="An article about cauliflower ears and why they're bad.">

--- a/articles/contact.html
+++ b/articles/contact.html
@@ -20,8 +20,6 @@
 
   <!-- Custom styles for this template -->
   <link href="css/clean-blog.min.css" rel="stylesheet">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5378984455419416"
-     crossorigin="anonymous"></script>
 </head>
 
 <body>

--- a/articles/index.html
+++ b/articles/index.html
@@ -2,12 +2,6 @@
 <html lang="en">
 
 <head>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="Brazilian Jiu-Jitsu and Chess Articles">
@@ -15,8 +9,6 @@
   <meta name="author" content="Tseren Zurganov">
 
   <title>ChessJitsu Articles</title>
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1304055128700343"
-     crossorigin="anonymous"></script>
   <!-- Bootstrap core CSS -->
   <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 

--- a/articles/khabibvstibau.html
+++ b/articles/khabibvstibau.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1304055128700343"
-     crossorigin="anonymous"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
   
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/articles/pedjones.html
+++ b/articles/pedjones.html
@@ -2,13 +2,6 @@
 <html lang="en">
 
 <head>
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-W5D9JW8QXC"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="A case review of Jon Jones doing steroids.">
@@ -28,8 +21,7 @@
    <!-- Custom styles for this template -->
   <link href="css/clean-blog.min.css" rel="stylesheet">
   
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5378984455419416"
-     crossorigin="anonymous"></script>  <script src="https://www.chessjitsu.net/articles/vendor/jquery/jquery.js"></script>
+<script src="https://www.chessjitsu.net/articles/vendor/jquery/jquery.js"></script>
     <script> 
     $(function(){
       $("#navbar_container").load("https://www.chessjitsu.net/navbar.html"); 

--- a/contact/index.html
+++ b/contact/index.html
@@ -3,12 +3,6 @@
 
 <head>
   
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="ChessJitsu Webmaster Page">
@@ -33,8 +27,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1304055128700343"
-     crossorigin="anonymous"></script>  <!-- Bootstrap core CSS -->
+<!-- Bootstrap core CSS -->
   <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">

--- a/footer.html
+++ b/footer.html
@@ -2,6 +2,7 @@
   <footer class="py-5 bg-dark">
     <div class="container">
       <p class="m-0 text-center text-white">Copyright &copy; ChessJitsu.net 2026</p>
+      <p class="mt-2 mb-0 text-center"><a class="text-white" href="/support/">App Support</a> <span class="text-white" aria-hidden="true">&middot;</span> <a class="text-white" href="/privacy/">Privacy</a></p>
     </div>
     <!-- /.container -->
   </footer>

--- a/playlists/index.html
+++ b/playlists/index.html
@@ -2,13 +2,6 @@
 <html lang="en">
 
 <head>
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-W5D9JW8QXC"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="">
@@ -32,7 +25,6 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script data-ad-client="ca-pub-1304055128700343" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
   <!-- Bootstrap core CSS -->
   <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Privacy policy for the ChessJitsu mobile app and ChessJitsu.net.">
+  <title>Privacy Policy | ChessJitsu</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <style>
+    :root { color-scheme: dark; }
+    body { max-width: 760px; margin: 0 auto; padding: 48px 22px; background: #0c0b11; color: #f5f2fa; font: 17px/1.65 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    a { color: #b66cff; }
+    h1, h2 { line-height: 1.2; }
+    h1 { margin-bottom: 0.25rem; }
+    h2 { margin-top: 2rem; }
+    .updated { color: #b9b2c4; margin-top: 0; }
+    .home { display: inline-block; margin-bottom: 2rem; }
+  </style>
+</head>
+<body>
+  <a class="home" href="/">&larr; ChessJitsu.net</a>
+  <main>
+    <h1>ChessJitsu Privacy Policy</h1>
+    <p class="updated">Effective August 21, 2026</p>
+    <p>This policy applies to the ChessJitsu mobile app and ChessJitsu.net.</p>
+
+    <h2>Information we collect</h2>
+    <p>ChessJitsu does not require an account and does not use analytics, advertising, or cross-app tracking technologies. We do not sell personal information.</p>
+
+    <h2>App and website operation</h2>
+    <p>The app provides access to ChessJitsu.net and includes three training videos stored on your device for offline playback. When the app or a browser opens ChessJitsu.net, standard technical information such as an IP address may be processed by the website hosting provider as necessary to deliver pages, prevent abuse, and maintain security.</p>
+
+    <h2>Third-party content and links</h2>
+    <p>Some website pages contain embedded media or links to services such as YouTube and social networks. Those services may receive standard connection information when their content is loaded or when you choose to visit them. Their own privacy policies govern their handling of information.</p>
+
+    <h2>Support email</h2>
+    <p>If you email us, we receive the email address, message, and any information you choose to include. We use it only to respond and provide support, and we do not sell it.</p>
+
+    <h2>Children</h2>
+    <p>ChessJitsu does not knowingly collect personal information from children.</p>
+
+    <h2>Changes</h2>
+    <p>If our data practices change, we will update this policy and any applicable app-store privacy disclosures.</p>
+
+    <h2>Contact</h2>
+    <p>Questions about privacy may be sent to <a href="mailto:tserenzurganov@gmail.com">tserenzurganov@gmail.com</a>.</p>
+  </main>
+</body>
+</html>

--- a/support/index.html
+++ b/support/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Support information for the ChessJitsu mobile app.">
+  <title>App Support | ChessJitsu</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <style>
+    :root { color-scheme: dark; }
+    body { max-width: 760px; margin: 0 auto; padding: 48px 22px; background: #0c0b11; color: #f5f2fa; font: 17px/1.65 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    a { color: #b66cff; }
+    h1, h2 { line-height: 1.2; }
+    h2 { margin-top: 2rem; }
+    .home { display: inline-block; margin-bottom: 2rem; }
+  </style>
+</head>
+<body>
+  <a class="home" href="/">&larr; ChessJitsu.net</a>
+  <main>
+    <h1>ChessJitsu App Support</h1>
+    <p>For help with ChessJitsu: Mind Training, email <a href="mailto:tserenzurganov@gmail.com">tserenzurganov@gmail.com</a>.</p>
+
+    <h2>Offline training</h2>
+    <p>The three training videos are included with the app and can be played without an internet connection. The ChessJitsu.net section requires an active internet connection.</p>
+
+    <h2>Troubleshooting</h2>
+    <p>If a video does not play, fully close and reopen the app and confirm that your device has sufficient free storage. If website pages do not load, check your internet connection and try again.</p>
+    <p>When contacting support, please include your device model, operating-system version, and a short description of what happened.</p>
+
+    <h2>Privacy</h2>
+    <p>Read the <a href="/privacy/">ChessJitsu Privacy Policy</a>.</p>
+  </main>
+</body>
+</html>

--- a/tyson/tyson.html
+++ b/tyson/tyson.html
@@ -1,14 +1,7 @@
 <DOCTYPE html>
 <html>
 <body>
-<head><!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-W5D9JW8QXC"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-W5D9JW8QXC');
-</script>
+<head>
   <title>Mike Tyson App</title>
     <meta name=”keywords” content="Mike Tyson, Tony Ferguson, UFC, MMA, BJJ, Brazilian Jiu-Jitsu, App">
   <meta name=”description” content="Mike Tyson says the darnest things”>
@@ -19,7 +12,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-<script data-ad-client="ca-pub-5378984455419416" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>  <!-- Bootstrap core CSS -->
+<!-- Bootstrap core CSS -->
   <link href="https://paradoxbjj.com/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
   <!-- Custom styles for this template -->


### PR DESCRIPTION
## Summary
- remove Google Analytics and Google AdSense code from every page in the repository
- add public ChessJitsu app privacy and support pages
- link the new pages from the shared site footer

## Verification
- repository-wide scan finds no Google Analytics or AdSense identifiers
- git diff whitespace checks pass

## Planned public URLs
- https://www.chessjitsu.net/privacy/
- https://www.chessjitsu.net/support/